### PR TITLE
More patch tweaks and fixes

### DIFF
--- a/src/Boot/Patches/Patches405.cpp
+++ b/src/Boot/Patches/Patches405.cpp
@@ -36,6 +36,8 @@ void Mira::Boot::Patches::install_prerunPatches_405()
 	kmem[3] = 0x00;
 	kmem[4] = 0x00;
 	kmem[5] = 0xC3;
+	kmem[6] = 0x90;
+	kmem[7] = 0x90;
 
 	kmem = (uint8_t *)&gKernelBase[0x00360570];
 	kmem[0] = 0xB8;
@@ -44,6 +46,8 @@ void Mira::Boot::Patches::install_prerunPatches_405()
 	kmem[3] = 0x00;
 	kmem[4] = 0x00;
 	kmem[5] = 0xC3;
+	kmem[6] = 0x90;
+	kmem[7] = 0x90;
 
 	kmem = (uint8_t *)&gKernelBase[0x00360590];
 	kmem[0] = 0xB8;
@@ -52,6 +56,8 @@ void Mira::Boot::Patches::install_prerunPatches_405()
 	kmem[3] = 0x00;
 	kmem[4] = 0x00;
 	kmem[5] = 0xC3;
+	kmem[6] = 0x90;
+	kmem[7] = 0x90;
 
 	// Enable rwx mapping
 	kmem = (uint8_t *)&gKernelBase[0x0036958D];
@@ -145,17 +151,20 @@ void Mira::Boot::Patches::install_prerunPatches_405()
 	kmem[0] = 0x31;
 	kmem[1] = 0xC0;
 	kmem[2] = 0xC3;
+	kmem[3] = 0x90;
 
 	// flatz enable debug RIFs
 	kmem = (uint8_t *)&gKernelBase[0x00620B20];
 	kmem[0] = 0xB0;
 	kmem[1] = 0x01;
 	kmem[2] = 0xC3;
+	kmem[3] = 0x90;
 
 	kmem = (uint8_t *)&gKernelBase[0x00620B40];
 	kmem[0] = 0xB0;
 	kmem[1] = 0x01;
 	kmem[2] = 0xC3;
+	kmem[3] = 0x90;
 
 	// Enable *all* debugging logs (in vprintf)
 	kmem = (uint8_t *)&gKernelBase[0x00347665];
@@ -189,6 +198,10 @@ void Mira::Boot::Patches::install_prerunPatches_405()
 	kmem[1] = 0x00;
 	kmem[2] = 0x00;
 	kmem[3] = 0x00;
+
+	// prtinf hook patches
+	kmem = (uint8_t *)&gKernelBase[0x0034766E];
+	kmem[0] = 0xEB;
 
 #endif
 }

--- a/src/Boot/Patches/Patches405.cpp
+++ b/src/Boot/Patches/Patches405.cpp
@@ -36,8 +36,6 @@ void Mira::Boot::Patches::install_prerunPatches_405()
 	kmem[3] = 0x00;
 	kmem[4] = 0x00;
 	kmem[5] = 0xC3;
-	kmem[6] = 0x90;
-	kmem[7] = 0x90;
 
 	kmem = (uint8_t *)&gKernelBase[0x00360570];
 	kmem[0] = 0xB8;
@@ -46,8 +44,6 @@ void Mira::Boot::Patches::install_prerunPatches_405()
 	kmem[3] = 0x00;
 	kmem[4] = 0x00;
 	kmem[5] = 0xC3;
-	kmem[6] = 0x90;
-	kmem[7] = 0x90;
 
 	kmem = (uint8_t *)&gKernelBase[0x00360590];
 	kmem[0] = 0xB8;
@@ -56,8 +52,6 @@ void Mira::Boot::Patches::install_prerunPatches_405()
 	kmem[3] = 0x00;
 	kmem[4] = 0x00;
 	kmem[5] = 0xC3;
-	kmem[6] = 0x90;
-	kmem[7] = 0x90;
 
 	// Enable rwx mapping
 	kmem = (uint8_t *)&gKernelBase[0x0036958D];
@@ -151,20 +145,17 @@ void Mira::Boot::Patches::install_prerunPatches_405()
 	kmem[0] = 0x31;
 	kmem[1] = 0xC0;
 	kmem[2] = 0xC3;
-	kmem[3] = 0x90;
 
 	// flatz enable debug RIFs
 	kmem = (uint8_t *)&gKernelBase[0x00620B20];
 	kmem[0] = 0xB0;
 	kmem[1] = 0x01;
 	kmem[2] = 0xC3;
-	kmem[3] = 0x90;
 
 	kmem = (uint8_t *)&gKernelBase[0x00620B40];
 	kmem[0] = 0xB0;
 	kmem[1] = 0x01;
 	kmem[2] = 0xC3;
-	kmem[3] = 0x90;
 
 	// Enable *all* debugging logs (in vprintf)
 	kmem = (uint8_t *)&gKernelBase[0x00347665];

--- a/src/Boot/Patches/Patches455.cpp
+++ b/src/Boot/Patches/Patches455.cpp
@@ -43,8 +43,6 @@ void Mira::Boot::Patches::install_prerunPatches_455()
 	kmem[3] = 0x00;
 	kmem[4] = 0x00;
 	kmem[5] = 0xC3;
-	kmem[6] = 0x90;
-	kmem[7] = 0x90;
 
 	kmem = (uint8_t *)&gKernelBase[0x0016A530];
 	kmem[0] = 0xB8;
@@ -53,8 +51,6 @@ void Mira::Boot::Patches::install_prerunPatches_455()
 	kmem[3] = 0x00;
 	kmem[4] = 0x00;
 	kmem[5] = 0xC3;
-	kmem[6] = 0x90;
-	kmem[7] = 0x90;
 
 	kmem = (uint8_t *)&gKernelBase[0x0016A550];
 	kmem[0] = 0xB8;
@@ -63,8 +59,6 @@ void Mira::Boot::Patches::install_prerunPatches_455()
 	kmem[3] = 0x00;
 	kmem[4] = 0x00;
 	kmem[5] = 0xC3;
-	kmem[6] = 0x90;
-	kmem[7] = 0x90;
 
 	// Enable rwx mapping
 	// Done by WildCard
@@ -168,20 +162,17 @@ void Mira::Boot::Patches::install_prerunPatches_455()
 	kmem[0] = 0x31;
 	kmem[1] = 0xC0;
 	kmem[2] = 0xC3;
-	kmem[3] = 0x90;
 
 	// flatz enable debug RIFs
 	kmem = (uint8_t *)&gKernelBase[0x0062D720];
 	kmem[0] = 0xB0;
 	kmem[1] = 0x01;
 	kmem[2] = 0xC3;
-	kmem[3] = 0x90;
 
 	kmem = (uint8_t *)&gKernelBase[0x0062D740];
 	kmem[0] = 0xB0;
 	kmem[1] = 0x01;
 	kmem[2] = 0xC3;
-	kmem[3] = 0x90;
 
 	// Enable *all* debugging logs (in vprintf)
 	// Patch by: SiSTRo (ported by kiwidog)

--- a/src/Boot/Patches/Patches455.cpp
+++ b/src/Boot/Patches/Patches455.cpp
@@ -43,6 +43,8 @@ void Mira::Boot::Patches::install_prerunPatches_455()
 	kmem[3] = 0x00;
 	kmem[4] = 0x00;
 	kmem[5] = 0xC3;
+	kmem[6] = 0x90;
+	kmem[7] = 0x90;
 
 	kmem = (uint8_t *)&gKernelBase[0x0016A530];
 	kmem[0] = 0xB8;
@@ -51,6 +53,8 @@ void Mira::Boot::Patches::install_prerunPatches_455()
 	kmem[3] = 0x00;
 	kmem[4] = 0x00;
 	kmem[5] = 0xC3;
+	kmem[6] = 0x90;
+	kmem[7] = 0x90;
 
 	kmem = (uint8_t *)&gKernelBase[0x0016A550];
 	kmem[0] = 0xB8;
@@ -59,6 +63,8 @@ void Mira::Boot::Patches::install_prerunPatches_455()
 	kmem[3] = 0x00;
 	kmem[4] = 0x00;
 	kmem[5] = 0xC3;
+	kmem[6] = 0x90;
+	kmem[7] = 0x90;
 
 	// Enable rwx mapping
 	// Done by WildCard
@@ -162,17 +168,20 @@ void Mira::Boot::Patches::install_prerunPatches_455()
 	kmem[0] = 0x31;
 	kmem[1] = 0xC0;
 	kmem[2] = 0xC3;
+	kmem[3] = 0x90;
 
 	// flatz enable debug RIFs
 	kmem = (uint8_t *)&gKernelBase[0x0062D720];
 	kmem[0] = 0xB0;
 	kmem[1] = 0x01;
 	kmem[2] = 0xC3;
+	kmem[3] = 0x90;
 
 	kmem = (uint8_t *)&gKernelBase[0x0062D740];
 	kmem[0] = 0xB0;
 	kmem[1] = 0x01;
 	kmem[2] = 0xC3;
+	kmem[3] = 0x90;
 
 	// Enable *all* debugging logs (in vprintf)
 	// Patch by: SiSTRo (ported by kiwidog)
@@ -212,6 +221,14 @@ void Mira::Boot::Patches::install_prerunPatches_455()
 	kmem[1] = 0x00;
 	kmem[2] = 0x00;
 	kmem[3] = 0x00;
+
+	// prtinf hook patches
+	kmem = (uint8_t *)&gKernelBase[0x00018026];
+	kmem[0] = 0xEB;
+	kmem[1] = 0x2D;
+
+	kmem = (uint8_t *)&gKernelBase[0x00018049];
+	kmem[0] = 0xEB;
 
 #endif
 }

--- a/src/Boot/Patches/Patches474.cpp
+++ b/src/Boot/Patches/Patches474.cpp
@@ -105,16 +105,13 @@ void Mira::Boot::Patches::install_prerunPatches_474()
 	kmem[0] = 0xEB;
 
 	// ptrace patches
-	kmem = (uint8_t *)&gKernelBase[0x0017C521];
-	kmem[0] = 0xEB;
-
-	// second ptrace patch
-	kmem = (uint8_t *)&gKernelBase[0x0017C896];
-	kmem[0] = 0xE9;
-	kmem[1] = 0x15;
-	kmem[2] = 0x01;
-	kmem[3] = 0x00;
-	kmem[4] = 0x00;
+	kmem = (uint8_t *)&gKernelBase[0x0017C54E];
+	kmem[0] = 0x90;
+	kmem[1] = 0x90;
+	kmem[2] = 0x90;
+	kmem[3] = 0x90;
+	kmem[4] = 0x90;
+	kmem[5] = 0x90;
 
 	// setlogin patch (for autolaunch check)
 	kmem = (uint8_t *)&gKernelBase[0x0011622C];

--- a/src/Boot/Patches/Patches474.cpp
+++ b/src/Boot/Patches/Patches474.cpp
@@ -34,6 +34,8 @@ void Mira::Boot::Patches::install_prerunPatches_474()
 	kmem[3] = 0x00;
 	kmem[4] = 0x00;
 	kmem[5] = 0xC3;
+	kmem[6] = 0x90;
+	kmem[7] = 0x90;
 
 	kmem = (uint8_t *)&gKernelBase[0x00169790];
 	kmem[0] = 0xB8;
@@ -42,6 +44,8 @@ void Mira::Boot::Patches::install_prerunPatches_474()
 	kmem[3] = 0x00;
 	kmem[4] = 0x00;
 	kmem[5] = 0xC3;
+	kmem[6] = 0x90;
+	kmem[7] = 0x90;
 
 	kmem = (uint8_t *)&gKernelBase[0x001697B0];
 	kmem[0] = 0xB8;
@@ -50,6 +54,8 @@ void Mira::Boot::Patches::install_prerunPatches_474()
 	kmem[3] = 0x00;
 	kmem[4] = 0x00;
 	kmem[5] = 0xC3;
+	kmem[6] = 0x90;
+	kmem[7] = 0x90;
 
 	// Enable rwx mapping
 	kmem = (uint8_t *)&gKernelBase[0x0016DFEC];
@@ -147,17 +153,20 @@ void Mira::Boot::Patches::install_prerunPatches_474()
 	kmem[0] = 0x31;
 	kmem[1] = 0xC0;
 	kmem[2] = 0xC3;
+	kmem[3] = 0x90;
 
 	// flatz enable debug RIFs
 	kmem = (uint8_t *)&gKernelBase[0x00630B10];
 	kmem[0] = 0xB0;
 	kmem[1] = 0x01;
 	kmem[2] = 0xC3;
+	kmem[3] = 0x90;
 
 	kmem = (uint8_t *)&gKernelBase[0x00630B30];
 	kmem[0] = 0xB0;
 	kmem[1] = 0x01;
 	kmem[2] = 0xC3;
+	kmem[3] = 0x90;
 
 	// Enable *all* debugging logs (in vprintf)
 	// Patch by: SiSTRo (ported by kiwidog)
@@ -197,6 +206,14 @@ void Mira::Boot::Patches::install_prerunPatches_474()
 	kmem[1] = 0x00;
 	kmem[2] = 0x00;
 	kmem[3] = 0x00;
+
+	// prtinf hook patches
+	kmem = (uint8_t *)&gKernelBase[0x00018026];
+	kmem[0] = 0xEB;
+	kmem[1] = 0x2D;
+
+	kmem = (uint8_t *)&gKernelBase[0x00018049];
+	kmem[0] = 0xEB;
 
 #endif
 }

--- a/src/Boot/Patches/Patches474.cpp
+++ b/src/Boot/Patches/Patches474.cpp
@@ -34,8 +34,6 @@ void Mira::Boot::Patches::install_prerunPatches_474()
 	kmem[3] = 0x00;
 	kmem[4] = 0x00;
 	kmem[5] = 0xC3;
-	kmem[6] = 0x90;
-	kmem[7] = 0x90;
 
 	kmem = (uint8_t *)&gKernelBase[0x00169790];
 	kmem[0] = 0xB8;
@@ -44,8 +42,6 @@ void Mira::Boot::Patches::install_prerunPatches_474()
 	kmem[3] = 0x00;
 	kmem[4] = 0x00;
 	kmem[5] = 0xC3;
-	kmem[6] = 0x90;
-	kmem[7] = 0x90;
 
 	kmem = (uint8_t *)&gKernelBase[0x001697B0];
 	kmem[0] = 0xB8;
@@ -54,8 +50,6 @@ void Mira::Boot::Patches::install_prerunPatches_474()
 	kmem[3] = 0x00;
 	kmem[4] = 0x00;
 	kmem[5] = 0xC3;
-	kmem[6] = 0x90;
-	kmem[7] = 0x90;
 
 	// Enable rwx mapping
 	kmem = (uint8_t *)&gKernelBase[0x0016DFEC];
@@ -153,20 +147,17 @@ void Mira::Boot::Patches::install_prerunPatches_474()
 	kmem[0] = 0x31;
 	kmem[1] = 0xC0;
 	kmem[2] = 0xC3;
-	kmem[3] = 0x90;
 
 	// flatz enable debug RIFs
 	kmem = (uint8_t *)&gKernelBase[0x00630B10];
 	kmem[0] = 0xB0;
 	kmem[1] = 0x01;
 	kmem[2] = 0xC3;
-	kmem[3] = 0x90;
 
 	kmem = (uint8_t *)&gKernelBase[0x00630B30];
 	kmem[0] = 0xB0;
 	kmem[1] = 0x01;
 	kmem[2] = 0xC3;
-	kmem[3] = 0x90;
 
 	// Enable *all* debugging logs (in vprintf)
 	// Patch by: SiSTRo (ported by kiwidog)

--- a/src/Boot/Patches/Patches501.cpp
+++ b/src/Boot/Patches/Patches501.cpp
@@ -34,8 +34,6 @@ void Mira::Boot::Patches::install_prerunPatches_501()
 	kmem[3] = 0x00;
 	kmem[4] = 0x00;
 	kmem[5] = 0xC3;
-	kmem[6] = 0x90;
-	kmem[7] = 0x90;
 
 	kmem = (uint8_t *)&gKernelBase[0x00011730];
 	kmem[0] = 0xB8;
@@ -44,8 +42,6 @@ void Mira::Boot::Patches::install_prerunPatches_501()
 	kmem[3] = 0x00;
 	kmem[4] = 0x00;
 	kmem[5] = 0xC3;
-	kmem[6] = 0x90;
-	kmem[7] = 0x90;
 
 	kmem = (uint8_t *)&gKernelBase[0x00011750];
 	kmem[0] = 0xB8;
@@ -54,8 +50,6 @@ void Mira::Boot::Patches::install_prerunPatches_501()
 	kmem[3] = 0x00;
 	kmem[4] = 0x00;
 	kmem[5] = 0xC3;
-	kmem[6] = 0x90;
-	kmem[7] = 0x90;
 
 	// Enable rwx mapping
 	kmem = (uint8_t *)&gKernelBase[0x000FCC38];
@@ -153,20 +147,17 @@ void Mira::Boot::Patches::install_prerunPatches_501()
 	kmem[0] = 0x31;
 	kmem[1] = 0xC0;
 	kmem[2] = 0xC3;
-	kmem[3] = 0x90;
 
 	// flatz enable debug RIFs
 	kmem = (uint8_t *)&gKernelBase[0x0064AED0];
 	kmem[0] = 0xB0;
 	kmem[1] = 0x01;
 	kmem[2] = 0xC3;
-	kmem[3] = 0x90;
 
 	kmem = (uint8_t *)&gKernelBase[0x0064AEF0];
 	kmem[0] = 0xB0;
 	kmem[1] = 0x01;
 	kmem[2] = 0xC3;
-	kmem[3] = 0x90;
 
 	// Enable *all* debugging logs (in vprintf)
 	// Patch by: SiSTRo (ported by kiwidog)

--- a/src/Boot/Patches/Patches501.cpp
+++ b/src/Boot/Patches/Patches501.cpp
@@ -34,8 +34,6 @@ void Mira::Boot::Patches::install_prerunPatches_501()
 	kmem[3] = 0x00;
 	kmem[4] = 0x00;
 	kmem[5] = 0xC3;
-	kmem[6] = 0x90;
-	kmem[7] = 0x90;
 
 	kmem = (uint8_t *)&gKernelBase[0x00011730];
 	kmem[0] = 0xB8;
@@ -44,8 +42,6 @@ void Mira::Boot::Patches::install_prerunPatches_501()
 	kmem[3] = 0x00;
 	kmem[4] = 0x00;
 	kmem[5] = 0xC3;
-	kmem[6] = 0x90;
-	kmem[7] = 0x90;
 
 	kmem = (uint8_t *)&gKernelBase[0x00011750];
 	kmem[0] = 0xB8;
@@ -54,8 +50,6 @@ void Mira::Boot::Patches::install_prerunPatches_501()
 	kmem[3] = 0x00;
 	kmem[4] = 0x00;
 	kmem[5] = 0xC3;
-	kmem[6] = 0x90;
-	kmem[7] = 0x90;
 
 	// Enable rwx mapping
 	kmem = (uint8_t *)&gKernelBase[0x000FCC38];
@@ -153,20 +147,17 @@ void Mira::Boot::Patches::install_prerunPatches_501()
 	kmem[0] = 0x31;
 	kmem[1] = 0xC0;
 	kmem[2] = 0xC3;
-	kmem[3] = 0x90;
 
 	// flatz enable debug RIFs
 	kmem = (uint8_t *)&gKernelBase[0x0064AED0];
 	kmem[0] = 0xB0;
 	kmem[1] = 0x01;
 	kmem[2] = 0xC3;
-	kmem[3] = 0x90;
 
 	kmem = (uint8_t *)&gKernelBase[0x0064AEF0];
 	kmem[0] = 0xB0;
 	kmem[1] = 0x01;
 	kmem[2] = 0xC3;
-	kmem[3] = 0x90;
 
 	// Enable *all* debugging logs (in vprintf)
 	// Patch by: SiSTRo (ported by kiwidog)
@@ -175,7 +166,7 @@ void Mira::Boot::Patches::install_prerunPatches_501()
 	kmem[1] = 0x38;
 
 	// flatz allow mangled symbol in dynlib_do_dlsym
-	kmem = (uint8_t *)&gKernelBase[0x002AF877];
+	kmem = (uint8_t *)&gKernelBase[0x002AFB47];
 	kmem[0] = 0x90;
 	kmem[1] = 0x90;
 	kmem[2] = 0x90;
@@ -184,7 +175,7 @@ void Mira::Boot::Patches::install_prerunPatches_501()
 	kmem[5] = 0x90;
 
 	// Enable mount for unprivileged user
-	kmem = (uint8_t *)&gKernelBase[0x001DEAEE];
+	kmem = (uint8_t *)&gKernelBase[0x001DEBFE];
 	kmem[0] = 0x90;
 	kmem[1] = 0x90;
 	kmem[2] = 0x90;

--- a/src/Boot/Patches/Patches501.cpp
+++ b/src/Boot/Patches/Patches501.cpp
@@ -34,6 +34,8 @@ void Mira::Boot::Patches::install_prerunPatches_501()
 	kmem[3] = 0x00;
 	kmem[4] = 0x00;
 	kmem[5] = 0xC3;
+	kmem[6] = 0x90;
+	kmem[7] = 0x90;
 
 	kmem = (uint8_t *)&gKernelBase[0x00011730];
 	kmem[0] = 0xB8;
@@ -42,6 +44,8 @@ void Mira::Boot::Patches::install_prerunPatches_501()
 	kmem[3] = 0x00;
 	kmem[4] = 0x00;
 	kmem[5] = 0xC3;
+	kmem[6] = 0x90;
+	kmem[7] = 0x90;
 
 	kmem = (uint8_t *)&gKernelBase[0x00011750];
 	kmem[0] = 0xB8;
@@ -50,6 +54,8 @@ void Mira::Boot::Patches::install_prerunPatches_501()
 	kmem[3] = 0x00;
 	kmem[4] = 0x00;
 	kmem[5] = 0xC3;
+	kmem[6] = 0x90;
+	kmem[7] = 0x90;
 
 	// Enable rwx mapping
 	kmem = (uint8_t *)&gKernelBase[0x000FCC38];
@@ -147,17 +153,20 @@ void Mira::Boot::Patches::install_prerunPatches_501()
 	kmem[0] = 0x31;
 	kmem[1] = 0xC0;
 	kmem[2] = 0xC3;
+	kmem[3] = 0x90;
 
 	// flatz enable debug RIFs
 	kmem = (uint8_t *)&gKernelBase[0x0064AED0];
 	kmem[0] = 0xB0;
 	kmem[1] = 0x01;
 	kmem[2] = 0xC3;
+	kmem[3] = 0x90;
 
 	kmem = (uint8_t *)&gKernelBase[0x0064AEF0];
 	kmem[0] = 0xB0;
 	kmem[1] = 0x01;
 	kmem[2] = 0xC3;
+	kmem[3] = 0x90;
 
 	// Enable *all* debugging logs (in vprintf)
 	// Patch by: SiSTRo (ported by kiwidog)
@@ -206,6 +215,15 @@ void Mira::Boot::Patches::install_prerunPatches_501()
 	kmem[1] = 0x00;
 	kmem[2] = 0x00;
 	kmem[3] = 0x00;
+
+	// prtinf hook patches
+	kmem = (uint8_t *)&gKernelBase[0x00435D66];
+	kmem[0] = 0xEB;
+	kmem[1] = 0x1E;
+
+	kmem = (uint8_t *)&gKernelBase[0x00435D84];
+	kmem[0] = 0x90;
+	kmem[1] = 0x90;
 
 #endif
 }

--- a/src/Boot/Patches/Patches503.cpp
+++ b/src/Boot/Patches/Patches503.cpp
@@ -34,6 +34,8 @@ void Mira::Boot::Patches::install_prerunPatches_503()
 	kmem[3] = 0x00;
 	kmem[4] = 0x00;
 	kmem[5] = 0xC3;
+	kmem[6] = 0x90;
+	kmem[7] = 0x90;
 
 	kmem = (uint8_t *)&gKernelBase[0x00011730];
 	kmem[0] = 0xB8;
@@ -42,6 +44,8 @@ void Mira::Boot::Patches::install_prerunPatches_503()
 	kmem[3] = 0x00;
 	kmem[4] = 0x00;
 	kmem[5] = 0xC3;
+	kmem[6] = 0x90;
+	kmem[7] = 0x90;
 
 	kmem = (uint8_t *)&gKernelBase[0x00011750];
 	kmem[0] = 0xB8;
@@ -50,6 +54,8 @@ void Mira::Boot::Patches::install_prerunPatches_503()
 	kmem[3] = 0x00;
 	kmem[4] = 0x00;
 	kmem[5] = 0xC3;
+	kmem[6] = 0x90;
+	kmem[7] = 0x90;
 
 	// Enable rwx mapping
 	kmem = (uint8_t *)&gKernelBase[0x000FCD48];
@@ -147,17 +153,20 @@ void Mira::Boot::Patches::install_prerunPatches_503()
 	kmem[0] = 0x31;
 	kmem[1] = 0xC0;
 	kmem[2] = 0xC3;
+	kmem[3] = 0x90;
 
 	// flatz enable debug RIFs
 	kmem = (uint8_t *)&gKernelBase[0x0064B270];
 	kmem[0] = 0xB0;
 	kmem[1] = 0x01;
 	kmem[2] = 0xC3;
+	kmem[3] = 0x90;
 
 	kmem = (uint8_t *)&gKernelBase[0x0064B290];
 	kmem[0] = 0xB0;
 	kmem[1] = 0x01;
 	kmem[2] = 0xC3;
+	kmem[3] = 0x90;
 
 	// Enable *all* debugging logs (in vprintf)
 	// Patch by: SiSTRo
@@ -166,7 +175,7 @@ void Mira::Boot::Patches::install_prerunPatches_503()
 	kmem[1] = 0x38;
 
 	// flatz allow mangled symbol in dynlib_do_dlsym
-	kmem = (uint8_t *)&gKernelBase[0x002AFB47];
+	kmem = (uint8_t *)&gKernelBase[0x002AF877];
 	kmem[0] = 0x90;
 	kmem[1] = 0x90;
 	kmem[2] = 0x90;
@@ -175,7 +184,7 @@ void Mira::Boot::Patches::install_prerunPatches_503()
 	kmem[5] = 0x90;
 
 	// Enable mount for unprivileged user
-	kmem = (uint8_t *)&gKernelBase[0x001DEBFE];
+	kmem = (uint8_t *)&gKernelBase[0x001DEAEE];
 	kmem[0] = 0x90;
 	kmem[1] = 0x90;
 	kmem[2] = 0x90;
@@ -206,6 +215,15 @@ void Mira::Boot::Patches::install_prerunPatches_503()
 	kmem[1] = 0x00;
 	kmem[2] = 0x00;
 	kmem[3] = 0x00;
+
+	// prtinf hook patches
+	kmem = (uint8_t *)&gKernelBase[0x004360F6];
+	kmem[0] = 0xEB;
+	kmem[1] = 0x1E;
+
+	kmem = (uint8_t *)&gKernelBase[0x00436114];
+	kmem[0] = 0x90;
+	kmem[1] = 0x90;
 
 #endif
 }

--- a/src/Boot/Patches/Patches503.cpp
+++ b/src/Boot/Patches/Patches503.cpp
@@ -34,8 +34,6 @@ void Mira::Boot::Patches::install_prerunPatches_503()
 	kmem[3] = 0x00;
 	kmem[4] = 0x00;
 	kmem[5] = 0xC3;
-	kmem[6] = 0x90;
-	kmem[7] = 0x90;
 
 	kmem = (uint8_t *)&gKernelBase[0x00011730];
 	kmem[0] = 0xB8;
@@ -44,8 +42,6 @@ void Mira::Boot::Patches::install_prerunPatches_503()
 	kmem[3] = 0x00;
 	kmem[4] = 0x00;
 	kmem[5] = 0xC3;
-	kmem[6] = 0x90;
-	kmem[7] = 0x90;
 
 	kmem = (uint8_t *)&gKernelBase[0x00011750];
 	kmem[0] = 0xB8;
@@ -54,8 +50,6 @@ void Mira::Boot::Patches::install_prerunPatches_503()
 	kmem[3] = 0x00;
 	kmem[4] = 0x00;
 	kmem[5] = 0xC3;
-	kmem[6] = 0x90;
-	kmem[7] = 0x90;
 
 	// Enable rwx mapping
 	kmem = (uint8_t *)&gKernelBase[0x000FCD48];
@@ -153,20 +147,17 @@ void Mira::Boot::Patches::install_prerunPatches_503()
 	kmem[0] = 0x31;
 	kmem[1] = 0xC0;
 	kmem[2] = 0xC3;
-	kmem[3] = 0x90;
 
 	// flatz enable debug RIFs
 	kmem = (uint8_t *)&gKernelBase[0x0064B270];
 	kmem[0] = 0xB0;
 	kmem[1] = 0x01;
 	kmem[2] = 0xC3;
-	kmem[3] = 0x90;
 
 	kmem = (uint8_t *)&gKernelBase[0x0064B290];
 	kmem[0] = 0xB0;
 	kmem[1] = 0x01;
 	kmem[2] = 0xC3;
-	kmem[3] = 0x90;
 
 	// Enable *all* debugging logs (in vprintf)
 	// Patch by: SiSTRo

--- a/src/Boot/Patches/Patches503.cpp
+++ b/src/Boot/Patches/Patches503.cpp
@@ -166,7 +166,7 @@ void Mira::Boot::Patches::install_prerunPatches_503()
 	kmem[1] = 0x38;
 
 	// flatz allow mangled symbol in dynlib_do_dlsym
-	kmem = (uint8_t *)&gKernelBase[0x002AF877];
+	kmem = (uint8_t *)&gKernelBase[0x002AFB47];
 	kmem[0] = 0x90;
 	kmem[1] = 0x90;
 	kmem[2] = 0x90;
@@ -175,7 +175,7 @@ void Mira::Boot::Patches::install_prerunPatches_503()
 	kmem[5] = 0x90;
 
 	// Enable mount for unprivileged user
-	kmem = (uint8_t *)&gKernelBase[0x001DEAEE];
+	kmem = (uint8_t *)&gKernelBase[0x001DEBFE];
 	kmem[0] = 0x90;
 	kmem[1] = 0x90;
 	kmem[2] = 0x90;

--- a/src/Boot/Patches/Patches505.cpp
+++ b/src/Boot/Patches/Patches505.cpp
@@ -34,8 +34,6 @@ void Mira::Boot::Patches::install_prerunPatches_505()
 	kmem[3] = 0x00;
 	kmem[4] = 0x00;
 	kmem[5] = 0xC3;
-	kmem[6] = 0x90;
-	kmem[7] = 0x90;
 
 	kmem = (uint8_t *)&gKernelBase[0x00011730];
 	kmem[0] = 0xB8;
@@ -44,8 +42,6 @@ void Mira::Boot::Patches::install_prerunPatches_505()
 	kmem[3] = 0x00;
 	kmem[4] = 0x00;
 	kmem[5] = 0xC3;
-	kmem[6] = 0x90;
-	kmem[7] = 0x90;
 
 	kmem = (uint8_t *)&gKernelBase[0x00011750];
 	kmem[0] = 0xB8;
@@ -54,8 +50,6 @@ void Mira::Boot::Patches::install_prerunPatches_505()
 	kmem[3] = 0x00;
 	kmem[4] = 0x00;
 	kmem[5] = 0xC3;
-	kmem[6] = 0x90;
-	kmem[7] = 0x90;
 
 	// Enable rwx mapping
 	kmem = (uint8_t *)&gKernelBase[0x000FCD48];
@@ -153,20 +147,17 @@ void Mira::Boot::Patches::install_prerunPatches_505()
 	kmem[0] = 0x31;
 	kmem[1] = 0xC0;
 	kmem[2] = 0xC3;
-	kmem[3] = 0x90;
 
 	// flatz enable debug RIFs
 	kmem = (uint8_t *)&gKernelBase[0x0064B2B0];
 	kmem[0] = 0xB0;
 	kmem[1] = 0x01;
 	kmem[2] = 0xC3;
-	kmem[3] = 0x90;
 
 	kmem = (uint8_t *)&gKernelBase[0x0064B2D0];
 	kmem[0] = 0xB0;
 	kmem[1] = 0x01;
 	kmem[2] = 0xC3;
-	kmem[3] = 0x90;
 
 	// Enable *all* debugging logs (in vprintf)
 	// Patch by: SiSTRo

--- a/src/Boot/Patches/Patches505.cpp
+++ b/src/Boot/Patches/Patches505.cpp
@@ -34,6 +34,8 @@ void Mira::Boot::Patches::install_prerunPatches_505()
 	kmem[3] = 0x00;
 	kmem[4] = 0x00;
 	kmem[5] = 0xC3;
+	kmem[6] = 0x90;
+	kmem[7] = 0x90;
 
 	kmem = (uint8_t *)&gKernelBase[0x00011730];
 	kmem[0] = 0xB8;
@@ -42,6 +44,8 @@ void Mira::Boot::Patches::install_prerunPatches_505()
 	kmem[3] = 0x00;
 	kmem[4] = 0x00;
 	kmem[5] = 0xC3;
+	kmem[6] = 0x90;
+	kmem[7] = 0x90;
 
 	kmem = (uint8_t *)&gKernelBase[0x00011750];
 	kmem[0] = 0xB8;
@@ -50,6 +54,8 @@ void Mira::Boot::Patches::install_prerunPatches_505()
 	kmem[3] = 0x00;
 	kmem[4] = 0x00;
 	kmem[5] = 0xC3;
+	kmem[6] = 0x90;
+	kmem[7] = 0x90;
 
 	// Enable rwx mapping
 	kmem = (uint8_t *)&gKernelBase[0x000FCD48];
@@ -147,17 +153,20 @@ void Mira::Boot::Patches::install_prerunPatches_505()
 	kmem[0] = 0x31;
 	kmem[1] = 0xC0;
 	kmem[2] = 0xC3;
+	kmem[3] = 0x90;
 
 	// flatz enable debug RIFs
 	kmem = (uint8_t *)&gKernelBase[0x0064B2B0];
 	kmem[0] = 0xB0;
 	kmem[1] = 0x01;
 	kmem[2] = 0xC3;
+	kmem[3] = 0x90;
 
 	kmem = (uint8_t *)&gKernelBase[0x0064B2D0];
 	kmem[0] = 0xB0;
 	kmem[1] = 0x01;
 	kmem[2] = 0xC3;
+	kmem[3] = 0x90;
 
 	// Enable *all* debugging logs (in vprintf)
 	// Patch by: SiSTRo
@@ -206,6 +215,15 @@ void Mira::Boot::Patches::install_prerunPatches_505()
 	kmem[1] = 0x00;
 	kmem[2] = 0x00;
 	kmem[3] = 0x00;
+
+	// prtinf hook patches
+	kmem = (uint8_t *)&gKernelBase[0x00436136];
+	kmem[0] = 0xEB;
+	kmem[1] = 0x1E;
+
+	kmem = (uint8_t *)&gKernelBase[0x00436154];
+	kmem[0] = 0x90;
+	kmem[1] = 0x90;
 
 #endif
 }

--- a/src/Utils/Kdlsym/Orbis405.hpp
+++ b/src/Utils/Kdlsym/Orbis405.hpp
@@ -33,6 +33,9 @@ for the platforms that do enable kernel ASLR (Address Space Layout Randomization
 #define kdlsym_addr_allproc                                0x01FE3498
 #define kdlsym_addr_allproc_lock                           0x01FE3438
 #define kdlsym_addr_avcontrol_sleep                        0x006AE670
+#define kdlsym_addr_cloneuio                               0x0035F810
+#define kdlsym_addr_console_cdev                           0x01A06FE0
+#define kdlsym_addr_console_write                          0x0026EB20
 #define kdlsym_addr_contigfree                             0x002761C0
 #define kdlsym_addr_contigmalloc                           0x00275E60
 #define kdlsym_addr_copyin                                 0x00286DF0
@@ -40,6 +43,7 @@ for the platforms that do enable kernel ASLR (Address Space Layout Randomization
 #define kdlsym_addr_copyout                                0x00286D70
 #define kdlsym_addr_critical_enter                         0x001E2660
 #define kdlsym_addr_critical_exit                          0x001E2670
+#define kdlsym_addr_deci_tty_write                         0x00470EF0
 #define kdlsym_addr_destroy_dev                            0x001F5BF0
 //#define kdlsym_addr_dmem_start_app_process                 0x0
 #define kdlsym_addr_dynlib_do_dlsym                        0x000E0770
@@ -75,6 +79,7 @@ for the platforms that do enable kernel ASLR (Address Space Layout Randomization
 #define kdlsym_addr_kproc_exit                             0x001C9590
 #define kdlsym_addr_kthread_add                            0x001C9890
 #define kdlsym_addr_kthread_exit                           0x001C9B60
+#define kdlsym_addr_M_IOV                                  0x01340C90
 #define kdlsym_addr_M_LINKER                               0x013468D0
 #define kdlsym_addr_M_MOUNT                                0x01356480
 #define kdlsym_addr_M_TEMP                                 0x0134B730
@@ -175,6 +180,9 @@ for the platforms that do enable kernel ASLR (Address Space Layout Randomization
 #define kdlsym_addr_vsnprintf                              0x00347900
 #define kdlsym_addr_wakeup                                 0x0008A7C0
 #define kdlsym_addr_Xfast_syscall                          0x0030EB30
+
+// Kernel Hooks
+#define kdlsym_addr_printf_hook                            0x018876A8
 
 // FakeSelf hooks
 #define kdlsym_addr_sceSblAuthMgrIsLoadable__sceSblACMgrGetPathId_hook        0x0061185C

--- a/src/Utils/Kdlsym/Orbis455.hpp
+++ b/src/Utils/Kdlsym/Orbis455.hpp
@@ -33,6 +33,9 @@ for the platforms that do enable kernel ASLR (Address Space Layout Randomization
 #define kdlsym_addr_allproc                                0x01AD7718
 #define kdlsym_addr_allproc_lock                           0x01AD76B8
 #define kdlsym_addr_avcontrol_sleep                        0x006C42E0
+#define kdlsym_addr_cloneuio                               0x00040420
+#define kdlsym_addr_console_cdev                           0x01A6CB08
+#define kdlsym_addr_console_write                          0x00030630
 #define kdlsym_addr_contigfree                             0x00250620
 #define kdlsym_addr_contigmalloc                           0x002502C0
 #define kdlsym_addr_copyin                                 0x0014A890
@@ -40,6 +43,7 @@ for the platforms that do enable kernel ASLR (Address Space Layout Randomization
 #define kdlsym_addr_copyout                                0x0014A7B0
 #define kdlsym_addr_critical_enter                         0x0023D560
 #define kdlsym_addr_critical_exit                          0x0023D570
+#define kdlsym_addr_deci_tty_write                         0x00474E40
 #define kdlsym_addr_destroy_dev                            0x0036EAD0
 //#define kdlsym_addr_dmem_start_app_process                 0x0
 #define kdlsym_addr_dynlib_do_dlsym                        0x00066A20
@@ -75,6 +79,7 @@ for the platforms that do enable kernel ASLR (Address Space Layout Randomization
 #define kdlsym_addr_kproc_exit                             0x00464980
 #define kdlsym_addr_kthread_add                            0x00464C90
 #define kdlsym_addr_kthread_exit                           0x00464F60
+#define kdlsym_addr_M_IOV                                  0x014447F0
 #define kdlsym_addr_M_LINKER                               0x0144A320
 #define kdlsym_addr_M_MOUNT                                0x0144F2A0
 #define kdlsym_addr_M_TEMP                                 0x01993B30
@@ -175,6 +180,9 @@ for the platforms that do enable kernel ASLR (Address Space Layout Randomization
 #define kdlsym_addr_vsnprintf                              0x000182D0
 #define kdlsym_addr_wakeup                                 0x00261140
 #define kdlsym_addr_Xfast_syscall                          0x003095D0
+
+// Kernel Hooks
+#define kdlsym_addr_printf_hook                            0x0199BDC8
 
 // FakeSelf hooks
 #define kdlsym_addr_sceSblAuthMgrIsLoadable__sceSblACMgrGetPathId_hook        0x0061F0FC

--- a/src/Utils/Kdlsym/Orbis474.hpp
+++ b/src/Utils/Kdlsym/Orbis474.hpp
@@ -50,7 +50,7 @@ for the platforms that do enable kernel ASLR (Address Space Layout Randomization
 #define kdlsym_addr_exec_new_vmspace                       0x002EAA50
 #define kdlsym_addr_faultin                                0x00311010
 #define kdlsym_addr_fget_unlocked                          0x0042DFD0
-#define kdlsym_addr_fpu_kern_ctx                           0x02528CC0
+#define kdlsym_addr_fpu_kern_ctx                           0x02549700
 #define kdlsym_addr_fpu_kern_enter                         0x00058B60
 #define kdlsym_addr_fpu_kern_leave                         0x00058C60
 #define kdlsym_addr_free                                   0x003F87A0

--- a/src/Utils/Kdlsym/Orbis474.hpp
+++ b/src/Utils/Kdlsym/Orbis474.hpp
@@ -33,6 +33,9 @@ for the platforms that do enable kernel ASLR (Address Space Layout Randomization
 #define kdlsym_addr_allproc                                0x01ADF718
 #define kdlsym_addr_allproc_lock                           0x01ADF6B8
 #define kdlsym_addr_avcontrol_sleep                        0x006C8560
+#define kdlsym_addr_cloneuio                               0x0003FA00
+#define kdlsym_addr_console_cdev                           0x01A74B08
+#define kdlsym_addr_console_write                          0x0002FC10
 #define kdlsym_addr_contigfree                             0x00252AA0
 #define kdlsym_addr_contigmalloc                           0x00252740
 #define kdlsym_addr_copyin                                 0x00149F20
@@ -40,6 +43,7 @@ for the platforms that do enable kernel ASLR (Address Space Layout Randomization
 #define kdlsym_addr_copyout                                0x00149E40
 #define kdlsym_addr_critical_enter                         0x0023F9E0
 #define kdlsym_addr_critical_exit                          0x0023F9F0
+#define kdlsym_addr_deci_tty_write                         0x00475CD0
 #define kdlsym_addr_destroy_dev                            0x0036F8F0
 //#define kdlsym_addr_dmem_start_app_process                 0x0
 #define kdlsym_addr_dynlib_do_dlsym                        0x00066000
@@ -50,7 +54,7 @@ for the platforms that do enable kernel ASLR (Address Space Layout Randomization
 #define kdlsym_addr_exec_new_vmspace                       0x002EAA50
 #define kdlsym_addr_faultin                                0x00311010
 #define kdlsym_addr_fget_unlocked                          0x0042DFD0
-#define kdlsym_addr_fpu_kern_ctx                           0x02549700
+#define kdlsym_addr_fpu_kern_ctx                           0x02528CC0
 #define kdlsym_addr_fpu_kern_enter                         0x00058B60
 #define kdlsym_addr_fpu_kern_leave                         0x00058C60
 #define kdlsym_addr_free                                   0x003F87A0
@@ -75,6 +79,7 @@ for the platforms that do enable kernel ASLR (Address Space Layout Randomization
 #define kdlsym_addr_kproc_exit                             0x00465810
 #define kdlsym_addr_kthread_add                            0x00465B20
 #define kdlsym_addr_kthread_exit                           0x00465DF0
+#define kdlsym_addr_M_IOV                                  0x0144C7F0
 #define kdlsym_addr_M_LINKER                               0x01452320
 #define kdlsym_addr_M_MOUNT                                0x014572A0
 #define kdlsym_addr_M_TEMP                                 0x0199BB80
@@ -175,6 +180,9 @@ for the platforms that do enable kernel ASLR (Address Space Layout Randomization
 #define kdlsym_addr_vsnprintf                              0x000182D0
 #define kdlsym_addr_wakeup                                 0x002635C0
 #define kdlsym_addr_Xfast_syscall                          0x0030B7D0
+
+// Kernel Hooks
+#define kdlsym_addr_printf_hook                            0x019A3E18
 
 // FakeSelf hooks
 #define kdlsym_addr_sceSblAuthMgrIsLoadable__sceSblACMgrGetPathId_hook        0x006224EC

--- a/src/Utils/Kdlsym/Orbis474.hpp
+++ b/src/Utils/Kdlsym/Orbis474.hpp
@@ -54,7 +54,7 @@ for the platforms that do enable kernel ASLR (Address Space Layout Randomization
 #define kdlsym_addr_exec_new_vmspace                       0x002EAA50
 #define kdlsym_addr_faultin                                0x00311010
 #define kdlsym_addr_fget_unlocked                          0x0042DFD0
-#define kdlsym_addr_fpu_kern_ctx                           0x02528CC0
+#define kdlsym_addr_fpu_kern_ctx                           0x02549700
 #define kdlsym_addr_fpu_kern_enter                         0x00058B60
 #define kdlsym_addr_fpu_kern_leave                         0x00058C60
 #define kdlsym_addr_free                                   0x003F87A0

--- a/src/Utils/Kdlsym/Orbis501.hpp
+++ b/src/Utils/Kdlsym/Orbis501.hpp
@@ -186,7 +186,7 @@ for the platforms that do enable kernel ASLR (Address Space Layout Randomization
 #define kdlsym_addr_sceSblAuthMgrIsLoadable__sceSblACMgrGetPathId_hook        0x0063DE7D
 #define kdlsym_addr_sceSblAuthMgrIsLoadable2_hook                             0x0063DFC1
 #define kdlsym_addr_sceSblAuthMgrSmLoadSelfSegment__sceSblServiceMailbox_hook 0x00642DAB
-#define kdlsym_addr_sceSblAuthMgrSmLoadSelfBlock__sceSblServiceMailbox_hook   0x006439AC
+#define kdlsym_addr_sceSblAuthMgrSmLoadSelfBlock__sceSblServiceMailbox_hook   0x006439C2
 #define kdlsym_addr_sceSblAuthMgrVerifyHeader_hookA                           0x0063E71C
 #define kdlsym_addr_sceSblAuthMgrVerifyHeader_hookB                           0x0063F338
 

--- a/src/Utils/Kdlsym/Orbis501.hpp
+++ b/src/Utils/Kdlsym/Orbis501.hpp
@@ -178,7 +178,7 @@ for the platforms that do enable kernel ASLR (Address Space Layout Randomization
 #define kdlsym_addr_sceSblAuthMgrIsLoadable__sceSblACMgrGetPathId_hook        0x0063DE7D
 #define kdlsym_addr_sceSblAuthMgrIsLoadable2_hook                             0x0063DFC1
 #define kdlsym_addr_sceSblAuthMgrSmLoadSelfSegment__sceSblServiceMailbox_hook 0x00642DAB
-#define kdlsym_addr_sceSblAuthMgrSmLoadSelfBlock__sceSblServiceMailbox_hook   0x006439AC
+#define kdlsym_addr_sceSblAuthMgrSmLoadSelfBlock__sceSblServiceMailbox_hook   0x006439C2
 #define kdlsym_addr_sceSblAuthMgrVerifyHeader_hookA                           0x0063E71C
 #define kdlsym_addr_sceSblAuthMgrVerifyHeader_hookB                           0x0063F338
 

--- a/src/Utils/Kdlsym/Orbis501.hpp
+++ b/src/Utils/Kdlsym/Orbis501.hpp
@@ -31,6 +31,9 @@ for the platforms that do enable kernel ASLR (Address Space Layout Randomization
 #define kdlsym_addr_allproc                                0x02382FF8
 #define kdlsym_addr_allproc_lock                           0x02382F98
 #define kdlsym_addr_avcontrol_sleep                        0x006EABD0
+#define kdlsym_addr_cloneuio                               0x002A8010
+#define kdlsym_addr_console_cdev                           0x01AC5158
+#define kdlsym_addr_console_write                          0x000ECB40
 #define kdlsym_addr_contigfree                             0x000F1EE0
 #define kdlsym_addr_contigmalloc                           0x000F1B10
 #define kdlsym_addr_copyin                                 0x001EA600
@@ -38,6 +41,7 @@ for the platforms that do enable kernel ASLR (Address Space Layout Randomization
 #define kdlsym_addr_copyout                                0x001EA520
 #define kdlsym_addr_critical_enter                         0x0028E4D0
 #define kdlsym_addr_critical_exit                          0x0028E4E0
+#define kdlsym_addr_deci_tty_write                         0x0049CB20
 #define kdlsym_addr_destroy_dev                            0x001B9C40
 #define kdlsym_addr_dmem_start_app_process                 0x002468E0
 #define kdlsym_addr_dynlib_do_dlsym                        0x002AF7B0
@@ -73,6 +77,7 @@ for the platforms that do enable kernel ASLR (Address Space Layout Randomization
 #define kdlsym_addr_kproc_exit                             0x00137F50
 #define kdlsym_addr_kthread_add                            0x00138250
 #define kdlsym_addr_kthread_exit                           0x00138530
+#define kdlsym_addr_M_IOV                                  0x014B5E80
 #define kdlsym_addr_M_LINKER                               0x019F2E10
 #define kdlsym_addr_M_MOUNT                                0x019BF300
 #define kdlsym_addr_M_TEMP                                 0x014B4110
@@ -174,11 +179,14 @@ for the platforms that do enable kernel ASLR (Address Space Layout Randomization
 #define kdlsym_addr_wakeup                                 0x003FB570
 #define kdlsym_addr_Xfast_syscall                          0x000001C0
 
+// Kernel Hooks
+#define kdlsym_addr_printf_hook                            0x019FC168
+
 // FakeSelf hooks
 #define kdlsym_addr_sceSblAuthMgrIsLoadable__sceSblACMgrGetPathId_hook        0x0063DE7D
 #define kdlsym_addr_sceSblAuthMgrIsLoadable2_hook                             0x0063DFC1
 #define kdlsym_addr_sceSblAuthMgrSmLoadSelfSegment__sceSblServiceMailbox_hook 0x00642DAB
-#define kdlsym_addr_sceSblAuthMgrSmLoadSelfBlock__sceSblServiceMailbox_hook   0x006439C2
+#define kdlsym_addr_sceSblAuthMgrSmLoadSelfBlock__sceSblServiceMailbox_hook   0x006439AC
 #define kdlsym_addr_sceSblAuthMgrVerifyHeader_hookA                           0x0063E71C
 #define kdlsym_addr_sceSblAuthMgrVerifyHeader_hookB                           0x0063F338
 

--- a/src/Utils/Kdlsym/Orbis503.hpp
+++ b/src/Utils/Kdlsym/Orbis503.hpp
@@ -31,6 +31,9 @@ for the platforms that do enable kernel ASLR (Address Space Layout Randomization
 #define kdlsym_addr_allproc                                0x02382FF8
 #define kdlsym_addr_allproc_lock                           0x02382F98
 #define kdlsym_addr_avcontrol_sleep                        0x006EAF70
+#define kdlsym_addr_cloneuio                               0x002A82E0
+#define kdlsym_addr_console_cdev                           0x01AC5158
+#define kdlsym_addr_console_write                          0x000ECAC0
 #define kdlsym_addr_contigfree                             0x000F1FF0
 #define kdlsym_addr_contigmalloc                           0x000F1C20
 #define kdlsym_addr_copyin                                 0x001EA710
@@ -38,6 +41,7 @@ for the platforms that do enable kernel ASLR (Address Space Layout Randomization
 #define kdlsym_addr_copyout                                0x001EA630
 #define kdlsym_addr_critical_enter                         0x0028E7A0
 #define kdlsym_addr_critical_exit                          0x0028E7B0
+#define kdlsym_addr_deci_tty_write                         0x0049CEB0
 #define kdlsym_addr_destroy_dev                            0x001B9D50
 #define kdlsym_addr_dmem_start_app_process                 0x002469F0
 #define kdlsym_addr_dynlib_do_dlsym                        0x002AFA80
@@ -73,6 +77,7 @@ for the platforms that do enable kernel ASLR (Address Space Layout Randomization
 #define kdlsym_addr_kproc_exit                             0x00138060
 #define kdlsym_addr_kthread_add                            0x00138360
 #define kdlsym_addr_kthread_exit                           0x00138640
+#define kdlsym_addr_M_IOV                                  0x014B5E80
 #define kdlsym_addr_M_LINKER                               0x019F2E10
 #define kdlsym_addr_M_MOUNT                                0x019BF300
 #define kdlsym_addr_M_TEMP                                 0x014B4110
@@ -173,6 +178,9 @@ for the platforms that do enable kernel ASLR (Address Space Layout Randomization
 #define kdlsym_addr_vsnprintf                              0x004363B0
 #define kdlsym_addr_wakeup                                 0x003FB940
 #define kdlsym_addr_Xfast_syscall                          0x000001C0
+
+// Kernel Hooks
+#define kdlsym_addr_printf_hook                            0x019FC168
 
 // FakeSelf hooks
 #define kdlsym_addr_sceSblAuthMgrIsLoadable__sceSblACMgrGetPathId_hook        0x0063E21D

--- a/src/Utils/Kdlsym/Orbis505.hpp
+++ b/src/Utils/Kdlsym/Orbis505.hpp
@@ -31,6 +31,9 @@ for the platforms that do enable kernel ASLR (Address Space Layout Randomization
 #define kdlsym_addr_allproc                                0x02382FF8
 #define kdlsym_addr_allproc_lock                           0x02382F98
 #define kdlsym_addr_avcontrol_sleep                        0x006EAFB0
+#define kdlsym_addr_cloneuio                               0x002A82E0
+#define kdlsym_addr_console_cdev                           0x01AC5158
+#define kdlsym_addr_console_write                          0x000ECAC0
 #define kdlsym_addr_contigfree                             0x000F1FF0
 #define kdlsym_addr_contigmalloc                           0x000F1C20
 #define kdlsym_addr_copyin                                 0x001EA710
@@ -38,6 +41,7 @@ for the platforms that do enable kernel ASLR (Address Space Layout Randomization
 #define kdlsym_addr_copyout                                0x001EA630
 #define kdlsym_addr_critical_enter                         0x0028E7A0
 #define kdlsym_addr_critical_exit                          0x0028E7B0
+#define kdlsym_addr_deci_tty_write                         0x0049CEF0
 #define kdlsym_addr_destroy_dev                            0x001B9D50
 #define kdlsym_addr_dmem_start_app_process                 0x002469F0
 #define kdlsym_addr_dynlib_do_dlsym                        0x002AFA80
@@ -73,6 +77,7 @@ for the platforms that do enable kernel ASLR (Address Space Layout Randomization
 #define kdlsym_addr_kproc_exit                             0x00138060
 #define kdlsym_addr_kthread_add                            0x00138360
 #define kdlsym_addr_kthread_exit                           0x00138640
+#define kdlsym_addr_M_IOV                                  0x014B5E80
 #define kdlsym_addr_M_LINKER                               0x019F2E10
 #define kdlsym_addr_M_MOUNT                                0x019BF300
 #define kdlsym_addr_M_TEMP                                 0x014B4110
@@ -108,6 +113,7 @@ for the platforms that do enable kernel ASLR (Address Space Layout Randomization
 #define kdlsym_addr_sbl_keymgr_key_rbtree                  0x02744558
 #define kdlsym_addr_sbl_keymgr_key_slots                   0x02744548
 #define kdlsym_addr_sbl_pfs_sx                             0x0271E5D8
+#define kdlsym_addr_sbl_drv_msg_mtx                        0x0271E210
 #define kdlsym_addr_sceSblACMgrGetPathId                   0x000117E0
 #define kdlsym_addr_sceSblAuthMgrIsLoadable2               0x0063C4F0
 #define kdlsym_addr_sceSblAuthMgrSmVerifyHeader            0x00642B40
@@ -173,6 +179,9 @@ for the platforms that do enable kernel ASLR (Address Space Layout Randomization
 #define kdlsym_addr_vsnprintf                              0x004363F0
 #define kdlsym_addr_wakeup                                 0x003FB940
 #define kdlsym_addr_Xfast_syscall                          0x000001C0
+
+// Kernel Hooks
+#define kdlsym_addr_printf_hook                            0x019FC168
 
 // FakeSelf hooks
 #define kdlsym_addr_sceSblAuthMgrIsLoadable__sceSblACMgrGetPathId_hook        0x0063E25D


### PR DESCRIPTION
- Fixed a 5.03 offset, put 5.01's instead.
  - Tested Mira + Font Sample from SDK on 5.03... it works!
- Fixed a 5.01 offset
  - Tested Mira + Font Sample from SDK on 5.01... it works!
- Fixed a 4.74 offset... and fixed a patch that I broke. 
  - Tested Mira + Font Sample from SDK on 4.74... it works!
- Removed 9 NOPs, per firmware, that weren't doing anything
- Added patches and offsets for the printf hook #51 