### PR TITLE
Add git hash to CI builds

### DIFF
--- a/.github/workflows/Orbis474.yml
+++ b/.github/workflows/Orbis474.yml
@@ -30,7 +30,7 @@ jobs:
       - name: make 4.74 loader
         run: cd loader; MIRA_PLATFORM=MIRA_PLATFORM_ORBIS_BSD_474 MIRA_CHECKS=TRUE make
       - name: make 4.74 elf
-        run: cd kernel; MIRA_PLATFORM=MIRA_PLATFORM_ORBIS_BSD_474 MIRA_CHECKS=TRUE make
+        run: cd kernel; MIRA_PLATFORM=MIRA_PLATFORM_ORBIS_BSD_474 ADD_GIT_HASH=TRUE MIRA_CHECKS=TRUE make
       - name: Upload 4.74 loader
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/Orbis501.yml
+++ b/.github/workflows/Orbis501.yml
@@ -30,7 +30,7 @@ jobs:
       - name: make 5.01 loader
         run: cd loader; MIRA_PLATFORM=MIRA_PLATFORM_ORBIS_BSD_501 MIRA_CHECKS=TRUE make
       - name: make 5.01 elf
-        run: cd kernel; MIRA_PLATFORM=MIRA_PLATFORM_ORBIS_BSD_501 MIRA_CHECKS=TRUE make
+        run: cd kernel; MIRA_PLATFORM=MIRA_PLATFORM_ORBIS_BSD_501 ADD_GIT_HASH=TRUE MIRA_CHECKS=TRUE make
       - name: Upload 5.01 loader
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/Orbis503.yml
+++ b/.github/workflows/Orbis503.yml
@@ -30,7 +30,7 @@ jobs:
       - name: make 5.03 loader
         run: cd loader; MIRA_PLATFORM=MIRA_PLATFORM_ORBIS_BSD_503 MIRA_CHECKS=TRUE make
       - name: make 5.03 elf
-        run: cd kernel; MIRA_PLATFORM=MIRA_PLATFORM_ORBIS_BSD_503 MIRA_CHECKS=TRUE make
+        run: cd kernel; MIRA_PLATFORM=MIRA_PLATFORM_ORBIS_BSD_503 ADD_GIT_HASH=TRUE MIRA_CHECKS=TRUE make
       - name: Upload 5.03 loader
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/Orbis505.yml
+++ b/.github/workflows/Orbis505.yml
@@ -30,7 +30,7 @@ jobs:
       - name: make 5.05 loader
         run: cd loader; MIRA_PLATFORM=MIRA_PLATFORM_ORBIS_BSD_505 MIRA_CHECKS=TRUE make
       - name: make 5.05 elf
-        run: cd kernel; MIRA_PLATFORM=MIRA_PLATFORM_ORBIS_BSD_505 MIRA_CHECKS=TRUE make
+        run: cd kernel; MIRA_PLATFORM=MIRA_PLATFORM_ORBIS_BSD_505 ADD_GIT_HASH=TRUE MIRA_CHECKS=TRUE make
       - name: Upload 5.05 loader
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/Orbis672.yml
+++ b/.github/workflows/Orbis672.yml
@@ -30,7 +30,7 @@ jobs:
       - name: make 6.72 loader
         run: cd loader; MIRA_PLATFORM=MIRA_PLATFORM_ORBIS_BSD_672 MIRA_CHECKS=TRUE make
       - name: make 6.72 elf
-        run: cd kernel; MIRA_PLATFORM=MIRA_PLATFORM_ORBIS_BSD_672 MIRA_CHECKS=TRUE make
+        run: cd kernel; MIRA_PLATFORM=MIRA_PLATFORM_ORBIS_BSD_672 ADD_GIT_HASH=TRUE MIRA_CHECKS=TRUE make
       - name: Upload 6.72 loader
         uses: actions/upload-artifact@v2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.so
 *SteamLink*
 *steam_link*
+src/GitHash.hpp
 build/*
 reeee/*
 # PVS-Studio Ignores

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -11,6 +11,11 @@ ifeq ($(MIRA_CHECKS),)
 MIRA_CHECKS :=
 endif
 
+# Should the Git hash be included in the build?
+ifeq ($(ADD_GIT_HASH),)
+ADD_GIT_HASH :=
+endif
+
 # Project name
 PROJ_NAME := Mira
 
@@ -57,7 +62,7 @@ I_DIRS	:=	-I. -I$(SRC_DIR) -I"$(BSD_INC)" -I$(EXTERNAL_INC) -I$(EXTERNAL_INC)/pr
 L_DIRS	:=	-L.	-Llib
 
 # Included libraries
-LIBS	:= 
+LIBS	:=
 
 # C Defines
 C_DEFS	:= -D_KERNEL=1 -D_DEBUG -D_STANDALONE -D"MIRA_PLATFORM=${MIRA_PLATFORM}" -DMIRA_UNSUPPORTED_PLATFORMS -D__LP64__ -D_M_X64 -D__amd64__ -D__BSD_VISIBLE
@@ -109,12 +114,17 @@ post-build: main-build
 main-build: pre-build
 	@echo "Building for Firmware $(MIRA_PLATFORM)..."
 	@echo $(I_DIRS)
+ifneq ($(strip $(ADD_GIT_HASH)),)
+	echo  -n '#ifndef GIT_HASH\n#define GIT_HASH "' > $(SRC_DIR)/GitHash.hpp && \
+	git rev-parse HEAD | tr -d "\n" >> $(SRC_DIR)/GitHash.hpp && \
+	echo  '"\n#endif' >> $(SRC_DIR)/GitHash.hpp
+endif
 ifneq ($(strip $(MIRA_CHECKS)),)
 	@scan-build $(MAKE) --no-print-directory $(ALL_OBJ)
 else
 	@$(MAKE) --no-print-directory $(ALL_OBJ)
 endif
-	
+
 $(OUT_DIR)/$(SRC_DIR)/%.o: $(SRC_DIR)/%.c
 	@echo "Compiling $< ..."
 ifneq ($(strip $(MIRA_CHECKS)),)
@@ -131,10 +141,11 @@ endif
 
 $(OUT_DIR)/$(SRC_DIR)/%.o: $(SRC_DIR)/%.s
 	@echo "Assembling $< ..."
-	@$(CC) $(SFLAGS) -c -o $@ $< 
+	@$(CC) $(SFLAGS) -c -o $@ $<
 
 clean:
 	@echo "Cleaning project..."
+	@rm -f $(SRC_DIR)/GitHash.hpp
 	@rm -f $(OUT_DIR)/$(TARGET) $(OUT_DIR)/$(PAYLOAD) $(shell find $(OUT_DIR)/ -type f -name '*.o')
 
 create:


### PR DESCRIPTION
Adds the git hash to the beginning of log files near the pointers. I'm sure something could be cleaned up but it currently works whether the hash is added or not. Should this be added in the loader as well? I wasn't sure were to add it in there.