### PR TITLE
PVS Fixes

### DIFF
--- a/kernel/src/Plugins/FakePkg/FakePkgManager.cpp
+++ b/kernel/src/Plugins/FakePkg/FakePkgManager.cpp
@@ -215,42 +215,42 @@ bool FakePkgManager::ShellCorePatch()
         WriteLog(LL_Error, "ssc_sceKernelIsGenuineCEX_patchB");
         return false;
     }
-    
+
     s_Ret = Utilities::ProcessReadWriteMemory(s_Process, (void*)(s_TextStart + ssc_sceKernelIsGenuineCEX_patchC), sizeof(xor__eax_eax), xor__eax_eax, nullptr, true);
     if (s_Ret < 0)
     {
         WriteLog(LL_Error, "ssc_sceKernelIsGenuineCEX_patchC");
         return false;
     }
-    
+
     s_Ret = Utilities::ProcessReadWriteMemory(s_Process, (void*)(s_TextStart + ssc_sceKernelIsGenuineCEX_patchD), sizeof(xor__eax_eax), xor__eax_eax, nullptr, true);
     if (s_Ret < 0)
     {
         WriteLog(LL_Error, "ssc_sceKernelIsGenuineCEX_patchD");
         return false;
     }
-    
+
     s_Ret = Utilities::ProcessReadWriteMemory(s_Process, (void*)(s_TextStart + ssc_nidf_libSceDipsw_patchA), sizeof(xor__eax_eax), xor__eax_eax, nullptr, true);
     if (s_Ret < 0)
     {
         WriteLog(LL_Error, "ssc_nidf_libSceDipsw_patchA");
         return false;
     }
-    
+
     s_Ret = Utilities::ProcessReadWriteMemory(s_Process, (void*)(s_TextStart + ssc_nidf_libSceDipsw_patchB), sizeof(xor__eax_eax), xor__eax_eax, nullptr, true);
     if (s_Ret < 0)
     {
         WriteLog(LL_Error, "ssc_nidf_libSceDipsw_patchB");
         return false;
     }
-    
+
     s_Ret = Utilities::ProcessReadWriteMemory(s_Process, (void*)(s_TextStart + ssc_nidf_libSceDipsw_patchC), sizeof(xor__eax_eax), xor__eax_eax, nullptr, true);
     if (s_Ret < 0)
     {
         WriteLog(LL_Error, "ssc_nidf_libSceDipsw_patchC");
         return false;
     }
-    
+
     s_Ret = Utilities::ProcessReadWriteMemory(s_Process, (void*)(s_TextStart + ssc_nidf_libSceDipsw_patchD), sizeof(xor__eax_eax), xor__eax_eax, nullptr, true);
     if (s_Ret < 0)
     {
@@ -343,7 +343,7 @@ bool FakePkgManager::ShellUIPatch()
     s_Entries = nullptr;
 
     // TODO: Fix all fw suport; I don't feel like fixing 1.76 support atm -kd
-    #if MIRA_PLATFORM <= MIRA_PLATFORM_ORBIS_BSD_176 || MIRA_PLATFORM > MIRA_PLATFORM_ORBIS_BSD_505 && MIRA_PLATFORM!=MIRA_PLATFORM_ORBIS_BSD_620 
+    #if MIRA_PLATFORM <= MIRA_PLATFORM_ORBIS_BSD_176 || MIRA_PLATFORM > MIRA_PLATFORM_ORBIS_BSD_505 && MIRA_PLATFORM!=MIRA_PLATFORM_ORBIS_BSD_620
     #else
 
     uint8_t mov__eax_1__ret[6] = { 0xB8, 0x01, 0x00, 0x00, 0x00, 0xC3 };
@@ -476,13 +476,13 @@ int FakePkgManager::DecryptNpdrmDebugRif(uint32_t p_Type, uint8_t* p_Data)
     auto s_Thread = __curthread();
     if (s_Thread == nullptr)
         return SCE_SBL_ERROR_NPDRM_ENOTSUP;
-    
+
     auto fpu_kern_enter = (int(*)(struct thread *td, struct fpu_kern_ctx *ctx, u_int flags))kdlsym(fpu_kern_enter);
     auto fpu_kern_leave = (int (*)(struct thread *td, struct fpu_kern_ctx *ctx))kdlsym(fpu_kern_leave);
     auto fpu_ctx = (fpu_kern_ctx*)kdlsym(fpu_kern_ctx);
     //auto AesCbcCfb128Encrypt = (int (*)(uint8_t* out, const uint8_t* in, size_t data_size, const uint8_t* key, int key_size, uint8_t* iv))kdlsym(AesCbcCfb128Encrypt);
     auto AesCbcCfb128Decrypt = (int (*)(uint8_t* out, const uint8_t* in, size_t data_size, const uint8_t* key, int key_size, uint8_t* iv))kdlsym(AesCbcCfb128Decrypt);
-    
+
     auto s_Ret = 0;
     fpu_kern_enter(s_Thread, fpu_ctx, 0);
     s_Ret = AesCbcCfb128Decrypt(p_Data + RIF_DIGEST_SIZE, p_Data + RIF_DIGEST_SIZE, RIF_DATA_SIZE, g_RifDebugKey, sizeof(g_RifDebugKey) * 8, p_Data);
@@ -531,10 +531,10 @@ vm_offset_t FakePkgManager::SceSblDriverGpuVaToCpuVa(vm_offset_t p_GpuVa, size_t
     auto s_Entry = SceSblDriverFindMappedPageListByGpuVa(p_GpuVa);
     if (s_Entry == nullptr)
         return 0;
-    
+
     if (p_NumPageGroups != nullptr)
         *p_NumPageGroups = s_Entry->numPageGroups;
-    
+
     return s_Entry->cpuVa;
 }
 
@@ -544,11 +544,11 @@ int FakePkgManager::OnSceSblDriverSendMsg(SblMsg* p_Message, size_t p_Size) __at
     auto sceSblDriverSendMsg = (int (*)(SblMsg* msg, size_t size))kdlsym(sceSblDriverSendMsg);
     if (p_Message->hdr.cmd != SBL_MSG_CCP)
         return sceSblDriverSendMsg(p_Message, p_Size);
-    
+
     union ccp_op* s_Op = &p_Message->service.ccp.op;
     if (CCP_OP(s_Op->common.cmd) != CCP_OP_AES)
         return sceSblDriverSendMsg(p_Message, p_Size);
-    
+
     uint32_t s_Mask = CCP_USE_KEY_FROM_SLOT | CCP_GENERATE_KEY_AT_SLOT;
     if ((s_Op->aes.cmd & s_Mask) != s_Mask || (s_Op->aes.key_index != PFS_FAKE_OBF_KEY_ID))
         return sceSblDriverSendMsg(p_Message, p_Size);
@@ -593,9 +593,9 @@ int FakePkgManager::OnSceSblPfsSetKeys(uint32_t* ekh, uint32_t* skh, uint8_t* ee
     int32_t ret, orig_ret = 0;
 
     ret = orig_ret = sceSblPfsSetKeys(ekh, skh, eekpfs, eekc, pubkey_ver, key_ver, hdr, hdr_size, type, finalized, is_disc);
-	
+
 	if (ret) {
-		if (finalized && is_disc != 0) 
+		if (finalized && is_disc != 0)
 		{
 			ret = sceSblPfsSetKeys(ekh, skh, eekpfs, eekc, pubkey_ver, key_ver, hdr, hdr_size, type, finalized, 0); /* always use is_disc=0 here */
 			if (ret) {
@@ -695,8 +695,6 @@ int FakePkgManager::OnSceSblPfsSetKeys(uint32_t* ekh, uint32_t* skh, uint8_t* ee
 				}
 			}
 			A_sx_xunlock_hard(sbl_pfs_sx);
-
-			ret = 0;
 		}
 	}
 
@@ -714,10 +712,10 @@ err:
         WriteLog(LL_Error, "sceSblPfsSetKeys returned (%x).", s_Ret);
         return s_Ret;
     }
-    
+
     if (p_Finalized && p_IsDisc != 0)
-    
-    
+
+
     uint8_t s_Ekpfs[EKPFS_SIZE] = { 0 };
     RsaBuffer s_InData
     {
@@ -755,7 +753,7 @@ err:
         WriteLog(LL_Error, "RsaesPkcs1v15Dec2048CRT returned (%x).", s_Ret);
         return s_OriginalRet;
     }
-    
+
     auto _sx_xlock = (int (*)(struct sx *sx, int opts))kdlsym(_sx_xlock);
     auto _sx_xunlock = (int (*)(struct sx *sx))kdlsym(_sx_xunlock);
 
@@ -815,7 +813,7 @@ err:
     {
         if (*p_Ekh != -1)
             sceSblKeymgrClearKey(*p_Ekh);
-        
+
         _sx_xunlock(sbl_pfs_sx);
         return s_OriginalRet;
     }
@@ -825,7 +823,7 @@ err:
     {
         if (*p_Skh != -1)
             sceSblKeymgrClearKey(*p_Skh);
-        
+
         _sx_xunlock(sbl_pfs_sx);
         return s_OriginalRet;
     }
@@ -841,7 +839,7 @@ int FakePkgManager::OnNpdrmDecryptIsolatedRif(KeymgrPayload* p_Payload)
     // it's SM request, thus we have the GPU address here, so we need to convert it to the CPU address
     KeymgrRequest* s_Request = reinterpret_cast<KeymgrRequest*>(SceSblDriverGpuVaToCpuVa(p_Payload->data, nullptr));
 
-    // // try to decrypt rif normally 
+    // // try to decrypt rif normally
     int s_Ret = sceSblKeymgrSmCallfunc(p_Payload);
     if ((s_Ret != 0 || p_Payload->status != 0) && s_Request)
     {
@@ -861,11 +859,11 @@ int FakePkgManager::OnNpdrmDecryptRifNew(KeymgrPayload* p_Payload)
 {
     auto sceSblKeymgrSmCallfunc = (int (*)(KeymgrPayload* payload))kdlsym(sceSblKeymgrSmCallfunc);
 
-    // it's SM request, thus we have the GPU address here, so we need to convert it to the CPU address 
+    // it's SM request, thus we have the GPU address here, so we need to convert it to the CPU address
     uint64_t s_BufferGpuVa = p_Payload->data;
     auto s_Request = reinterpret_cast<KeymgrRequest*>(SceSblDriverGpuVaToCpuVa(s_BufferGpuVa, nullptr));
     auto s_Response = reinterpret_cast<KeymgrResponse*>(s_Request);
-    
+
     // try to decrypt rif normally
     int s_Ret = sceSblKeymgrSmCallfunc(p_Payload);
     int s_OriginalRet = s_Ret;
@@ -874,9 +872,8 @@ int FakePkgManager::OnNpdrmDecryptRifNew(KeymgrPayload* p_Payload)
     if ((s_Ret != 0 || p_Payload->status != 0) && s_Request)
     {
         if (s_Request->DecryptEntireRif.rif.format != 2)
-        { 
+        {
             // not fake?
-            s_Ret = s_OriginalRet;
             goto err;
         }
 
@@ -892,16 +889,15 @@ int FakePkgManager::OnNpdrmDecryptRifNew(KeymgrPayload* p_Payload)
         consult with kernel code if offsets needs to be changed */
         memcpy(s_Response->DecryptEntireRif.raw, s_Request->DecryptEntireRif.rif.digest, sizeof(s_Request->DecryptEntireRif.rif.digest) + sizeof(s_Request->DecryptEntireRif.rif.data));
 
-        memset(s_Response->DecryptEntireRif.raw + 
+        memset(s_Response->DecryptEntireRif.raw +
         sizeof(s_Request->DecryptEntireRif.rif.digest) +
-        sizeof(s_Request->DecryptEntireRif.rif.data), 
+        sizeof(s_Request->DecryptEntireRif.rif.data),
         0,
-        sizeof(s_Response->DecryptEntireRif.raw) - 
-        (sizeof(s_Request->DecryptEntireRif.rif.digest) + 
+        sizeof(s_Response->DecryptEntireRif.raw) -
+        (sizeof(s_Request->DecryptEntireRif.rif.digest) +
         sizeof(s_Request->DecryptEntireRif.rif.data)));
 
         p_Payload->status = s_Ret;
-        s_Ret = 0;
     }
 
 err:
@@ -925,7 +921,7 @@ SblKeyRbtreeEntry* FakePkgManager::sceSblKeymgrGetKey(unsigned int p_Handle)
     return nullptr;
 }
 
-int FakePkgManager::OnSceSblKeymgrInvalidateKeySxXlock(struct sx* p_Sx, int p_Opts, const char* p_File, int p_Line) 
+int FakePkgManager::OnSceSblKeymgrInvalidateKeySxXlock(struct sx* p_Sx, int p_Opts, const char* p_File, int p_Line)
 {
     //WriteLog(LL_Debug, "OnSceSblKeymgrInvalidateKeySxXlock");
     auto sceSblKeymgrSetKeyStorage = (int (*)(uint64_t key_gpu_va, unsigned int key_size, uint32_t key_id, uint32_t key_handle))kdlsym(sceSblKeymgrSetKeyStorage);

--- a/kernel/src/Plugins/FakePkg/FakePkgManager.cpp
+++ b/kernel/src/Plugins/FakePkg/FakePkgManager.cpp
@@ -887,7 +887,8 @@ int FakePkgManager::OnNpdrmDecryptRifNew(KeymgrPayload* p_Payload)
 
         /* XXX: sorry, i'm lazy to refactor this crappy code :D basically, we're copying decrypted data to proper place,
         consult with kernel code if offsets needs to be changed */
-        memcpy(s_Response->DecryptEntireRif.raw, s_Request->DecryptEntireRif.rif.digest, sizeof(s_Request->DecryptEntireRif.rif.digest) + sizeof(s_Request->DecryptEntireRif.rif.data));
+        memcpy(s_Response->DecryptEntireRif.raw, s_Request->DecryptEntireRif.rif.digest, sizeof(s_Request->DecryptEntireRif.rif.digest));
+        memcpy(s_Response->DecryptEntireRif.raw + sizeof(s_Request->DecryptEntireRif.rif.digest), s_Request->DecryptEntireRif.rif.data, sizeof(s_Request->DecryptEntireRif.rif.data));
 
         memset(s_Response->DecryptEntireRif.raw +
         sizeof(s_Request->DecryptEntireRif.rif.digest) +

--- a/kernel/src/Plugins/FakePkg/FakePkgManager.cpp
+++ b/kernel/src/Plugins/FakePkg/FakePkgManager.cpp
@@ -113,7 +113,9 @@ FakePkgManager::FakePkgManager() :
     m_NpdrmDecryptRifNewHook(nullptr),
     m_SceSblDriverSendMsgHook(nullptr),
     m_SceSblKeymgrInvalidateKey(nullptr),
-    m_SceSblPfsSetKeysHook(nullptr)
+    m_SceSblPfsSetKeysHook(nullptr),
+    m_processStartEvent(nullptr),
+    m_resumeEvent(nullptr)
 {
     auto sv = (struct sysentvec*)kdlsym(self_orbis_sysvec);
     struct sysent* sysents = sv->sv_table;

--- a/kernel/src/Plugins/MorpheusEnabler/MorpheusEnabler.cpp
+++ b/kernel/src/Plugins/MorpheusEnabler/MorpheusEnabler.cpp
@@ -17,7 +17,9 @@ extern "C"
 using namespace Mira::Plugins;
 using namespace Mira::OrbisOS;
 
-MorpheusEnabler::MorpheusEnabler()
+MorpheusEnabler::MorpheusEnabler() :
+	m_processStartEvent(nullptr),
+	m_resumeEvent(nullptr)
 {
 
 }

--- a/kernel/src/Plugins/MorpheusEnabler/MorpheusEnabler.cpp
+++ b/kernel/src/Plugins/MorpheusEnabler/MorpheusEnabler.cpp
@@ -11,7 +11,7 @@
 extern "C"
 {
 	#include <sys/mman.h>
-    #include <sys/eventhandler.h>
+	#include <sys/eventhandler.h>
 };
 
 using namespace Mira::Plugins;
@@ -29,24 +29,23 @@ MorpheusEnabler::~MorpheusEnabler()
 
 void MorpheusEnabler::ProcessStartEvent(void *arg, struct ::proc *p)
 {
-    auto strncmp = (int(*)(const char *, const char *, size_t))kdlsym(strncmp);
+	auto strncmp = (int(*)(const char *, const char *, size_t))kdlsym(strncmp);
 
-    if (!p)
-        return;
+	if (!p)
+		return;
 
-    char* s_TitleId = (char*)((uint64_t)p + 0x390);
-    if (strncmp(s_TitleId, "NPXS20001", 9) == 0) {
-        DoPatch();
-    }
+	char* s_TitleId = (char*)((uint64_t)p + 0x390);
+	if (strncmp(s_TitleId, "NPXS20000", 9) == 0 && strcmp(p->p_comm, "SceShellCore") == 0)
+		DoPatch();
 
-    return;
+	return;
 }
 
 void MorpheusEnabler::ResumeEvent()
 {
-    DoPatch();
-    WriteLog(LL_Debug, "InstallEventHandlers finished");
-    return;
+	DoPatch();
+	WriteLog(LL_Debug, "InstallEventHandlers finished");
+	return;
 }
 
 bool MorpheusEnabler::DoPatch()
@@ -100,8 +99,8 @@ bool MorpheusEnabler::DoPatch()
 	s_Ret = Utilities::ProcessReadWriteMemory(s_Process, (void*)(s_TextStart + ssc_enable_vr_patch), 3, (void*)"\x31\xC0\xC3", nullptr, true);
 	if (s_Ret < 0)
 	{
-			WriteLog(LL_Error, "ssc_enable_vr");
-			return false;
+		WriteLog(LL_Error, "ssc_enable_vr");
+		return false;
 	}
 
 	return true;
@@ -110,35 +109,37 @@ bool MorpheusEnabler::DoPatch()
 bool MorpheusEnabler::OnLoad()
 {
 	auto s_MainThread = Mira::Framework::GetFramework()->GetMainThread();
-    if (s_MainThread == nullptr)
-    {
-        WriteLog(LL_Error, "could not get main mira thread");
-        return false;
-    }
+	if (s_MainThread == nullptr)
+	{
+		WriteLog(LL_Error, "could not get main mira thread");
+		return false;
+	}
 
-    // Initialize the event handlers
-    auto eventhandler_register = (eventhandler_tag(*)(struct eventhandler_list *list, const char *name, void *func, void *arg, int priority))kdlsym(eventhandler_register);
+	// Initialize the event handlers
+	auto eventhandler_register = (eventhandler_tag(*)(struct eventhandler_list *list, const char *name, void *func, void *arg, int priority))kdlsym(eventhandler_register);
 
-    m_processStartEvent = eventhandler_register(NULL, "process_exec_end", reinterpret_cast<void*>(MorpheusEnabler::ProcessStartEvent), NULL, EVENTHANDLER_PRI_LAST);
-    m_resumeEvent = eventhandler_register(NULL, "system_resume_phase4", reinterpret_cast<void*>(MorpheusEnabler::ResumeEvent), NULL, EVENTHANDLER_PRI_LAST);
+	m_processStartEvent = eventhandler_register(NULL, "process_exec_end", reinterpret_cast<void*>(MorpheusEnabler::ProcessStartEvent), NULL, EVENTHANDLER_PRI_LAST);
+	m_resumeEvent = eventhandler_register(NULL, "system_resume_phase4", reinterpret_cast<void*>(MorpheusEnabler::ResumeEvent), NULL, EVENTHANDLER_PRI_LAST);
 
 	return DoPatch();
 }
 
 bool MorpheusEnabler::OnUnload()
 {
-    auto eventhandler_deregister = (void(*)(struct eventhandler_list* a, struct eventhandler_entry* b))kdlsym(eventhandler_deregister);
-    auto eventhandler_find_list = (struct eventhandler_list * (*)(const char *name))kdlsym(eventhandler_find_list);
+	auto eventhandler_deregister = (void(*)(struct eventhandler_list* a, struct eventhandler_entry* b))kdlsym(eventhandler_deregister);
+	auto eventhandler_find_list = (struct eventhandler_list * (*)(const char *name))kdlsym(eventhandler_find_list);
 
-    if (m_processStartEvent) {
-        EVENTHANDLER_DEREGISTER(process_exec_end, m_processStartEvent);
-        m_processStartEvent = nullptr;
-    }
+	if (m_processStartEvent)
+	{
+		EVENTHANDLER_DEREGISTER(process_exec_end, m_processStartEvent);
+		m_processStartEvent = nullptr;
+	}
 
-    if (m_resumeEvent) {
-        EVENTHANDLER_DEREGISTER(process_exit, m_resumeEvent);
-        m_resumeEvent = nullptr;
-    }
+	if (m_resumeEvent)
+	{
+		EVENTHANDLER_DEREGISTER(process_exit, m_resumeEvent);
+		m_resumeEvent = nullptr;
+	}
 
 	return true;
 }

--- a/kernel/src/Plugins/MorpheusEnabler/MorpheusEnabler.cpp
+++ b/kernel/src/Plugins/MorpheusEnabler/MorpheusEnabler.cpp
@@ -11,7 +11,7 @@
 extern "C"
 {
 	#include <sys/mman.h>
-	#include <sys/eventhandler.h>
+    #include <sys/eventhandler.h>
 };
 
 using namespace Mira::Plugins;
@@ -31,23 +31,24 @@ MorpheusEnabler::~MorpheusEnabler()
 
 void MorpheusEnabler::ProcessStartEvent(void *arg, struct ::proc *p)
 {
-	auto strncmp = (int(*)(const char *, const char *, size_t))kdlsym(strncmp);
+    auto strncmp = (int(*)(const char *, const char *, size_t))kdlsym(strncmp);
 
-	if (!p)
-		return;
+    if (!p)
+        return;
 
-	char* s_TitleId = (char*)((uint64_t)p + 0x390);
-	if (strncmp(s_TitleId, "NPXS20000", 9) == 0 && strcmp(p->p_comm, "SceShellCore") == 0)
-		DoPatch();
+    char* s_TitleId = (char*)((uint64_t)p + 0x390);
+    if (strncmp(s_TitleId, "NPXS20001", 9) == 0) {
+        DoPatch();
+    }
 
-	return;
+    return;
 }
 
 void MorpheusEnabler::ResumeEvent()
 {
-	DoPatch();
-	WriteLog(LL_Debug, "InstallEventHandlers finished");
-	return;
+    DoPatch();
+    WriteLog(LL_Debug, "InstallEventHandlers finished");
+    return;
 }
 
 bool MorpheusEnabler::DoPatch()
@@ -101,8 +102,8 @@ bool MorpheusEnabler::DoPatch()
 	s_Ret = Utilities::ProcessReadWriteMemory(s_Process, (void*)(s_TextStart + ssc_enable_vr_patch), 3, (void*)"\x31\xC0\xC3", nullptr, true);
 	if (s_Ret < 0)
 	{
-		WriteLog(LL_Error, "ssc_enable_vr");
-		return false;
+			WriteLog(LL_Error, "ssc_enable_vr");
+			return false;
 	}
 
 	return true;
@@ -111,37 +112,35 @@ bool MorpheusEnabler::DoPatch()
 bool MorpheusEnabler::OnLoad()
 {
 	auto s_MainThread = Mira::Framework::GetFramework()->GetMainThread();
-	if (s_MainThread == nullptr)
-	{
-		WriteLog(LL_Error, "could not get main mira thread");
-		return false;
-	}
+    if (s_MainThread == nullptr)
+    {
+        WriteLog(LL_Error, "could not get main mira thread");
+        return false;
+    }
 
-	// Initialize the event handlers
-	auto eventhandler_register = (eventhandler_tag(*)(struct eventhandler_list *list, const char *name, void *func, void *arg, int priority))kdlsym(eventhandler_register);
+    // Initialize the event handlers
+    auto eventhandler_register = (eventhandler_tag(*)(struct eventhandler_list *list, const char *name, void *func, void *arg, int priority))kdlsym(eventhandler_register);
 
-	m_processStartEvent = eventhandler_register(NULL, "process_exec_end", reinterpret_cast<void*>(MorpheusEnabler::ProcessStartEvent), NULL, EVENTHANDLER_PRI_LAST);
-	m_resumeEvent = eventhandler_register(NULL, "system_resume_phase4", reinterpret_cast<void*>(MorpheusEnabler::ResumeEvent), NULL, EVENTHANDLER_PRI_LAST);
+    m_processStartEvent = eventhandler_register(NULL, "process_exec_end", reinterpret_cast<void*>(MorpheusEnabler::ProcessStartEvent), NULL, EVENTHANDLER_PRI_LAST);
+    m_resumeEvent = eventhandler_register(NULL, "system_resume_phase4", reinterpret_cast<void*>(MorpheusEnabler::ResumeEvent), NULL, EVENTHANDLER_PRI_LAST);
 
 	return DoPatch();
 }
 
 bool MorpheusEnabler::OnUnload()
 {
-	auto eventhandler_deregister = (void(*)(struct eventhandler_list* a, struct eventhandler_entry* b))kdlsym(eventhandler_deregister);
-	auto eventhandler_find_list = (struct eventhandler_list * (*)(const char *name))kdlsym(eventhandler_find_list);
+    auto eventhandler_deregister = (void(*)(struct eventhandler_list* a, struct eventhandler_entry* b))kdlsym(eventhandler_deregister);
+    auto eventhandler_find_list = (struct eventhandler_list * (*)(const char *name))kdlsym(eventhandler_find_list);
 
-	if (m_processStartEvent)
-	{
-		EVENTHANDLER_DEREGISTER(process_exec_end, m_processStartEvent);
-		m_processStartEvent = nullptr;
-	}
+    if (m_processStartEvent) {
+        EVENTHANDLER_DEREGISTER(process_exec_end, m_processStartEvent);
+        m_processStartEvent = nullptr;
+    }
 
-	if (m_resumeEvent)
-	{
-		EVENTHANDLER_DEREGISTER(process_exit, m_resumeEvent);
-		m_resumeEvent = nullptr;
-	}
+    if (m_resumeEvent) {
+        EVENTHANDLER_DEREGISTER(process_exit, m_resumeEvent);
+        m_resumeEvent = nullptr;
+    }
 
 	return true;
 }

--- a/kernel/src/Plugins/PluginManager.cpp
+++ b/kernel/src/Plugins/PluginManager.cpp
@@ -38,7 +38,8 @@ PluginManager::PluginManager() :
     m_BrowserActivator(nullptr),
     m_MorpheusEnabler(nullptr),
     m_RemotePlayEnabler(nullptr),
-    m_SyscallGuard(nullptr)
+    m_SyscallGuard(nullptr),
+    m_TTYRedirector(nullptr)
 {
     // Hushes error: private field 'm_FileManager' is not used [-Werror,-Wunused-private-field]
 	m_Logger = nullptr;
@@ -609,7 +610,7 @@ bool PluginManager::OnProcessExec(struct proc* p_Process)
 {
     if (p_Process == nullptr)
         return false;
-    
+
     if (m_Substitute)
     {
         if (!m_Substitute->OnProcessExec(p_Process))
@@ -629,7 +630,7 @@ bool PluginManager::OnProcessExecEnd(struct proc* p_Process)
 {
     if (p_Process == nullptr)
         return false;
-    
+
     if (m_Substitute)
     {
         if (!m_Substitute->OnProcessExecEnd(p_Process))
@@ -643,7 +644,7 @@ bool PluginManager::OnProcessExit(struct proc* p_Process)
 {
     if (p_Process == nullptr)
         return false;
-    
+
     if (m_Substitute)
     {
         if (!m_Substitute->OnProcessExit(p_Process))

--- a/kernel/src/Plugins/RemotePlayEnabler/RemotePlayEnabler.cpp
+++ b/kernel/src/Plugins/RemotePlayEnabler/RemotePlayEnabler.cpp
@@ -17,7 +17,9 @@ extern "C"
 using namespace Mira::Plugins;
 using namespace Mira::OrbisOS;
 
-RemotePlayEnabler::RemotePlayEnabler()
+RemotePlayEnabler::RemotePlayEnabler() :
+	m_processStartEvent(nullptr),
+	m_resumeEvent(nullptr)
 {
 
 }
@@ -240,7 +242,7 @@ bool RemotePlayEnabler::OnLoad()
 	{
 		WriteLog(LL_Error, "could not get main mira thread");
 		return false;
-  	}
+	}
 
 	// Initialize the event handlers
 	auto eventhandler_register = (eventhandler_tag(*)(struct eventhandler_list *list, const char *name, void *func, void *arg, int priority))kdlsym(eventhandler_register);
@@ -249,13 +251,15 @@ bool RemotePlayEnabler::OnLoad()
 	m_resumeEvent = eventhandler_register(NULL, "system_resume_phase4", reinterpret_cast<void*>(RemotePlayEnabler::ResumeEvent), NULL, EVENTHANDLER_PRI_LAST);
 
 	auto s_Ret = ShellUIPatch();
-	if (s_Ret == false) {
+	if (s_Ret == false)
+	{
 		WriteLog(LL_Error, "could not patch SceShellUI");
 		return false;
 	}
 
 	s_Ret = RemotePlayPatch();
-	if (s_Ret == false) {
+	if (s_Ret == false)
+	{
 		WriteLog(LL_Error, "could not patch SceRemotePlay");
 		return false;
 	}

--- a/kernel/src/Plugins/Substitute/Substitute.cpp
+++ b/kernel/src/Plugins/Substitute/Substitute.cpp
@@ -63,7 +63,7 @@ bool Substitute::OnLoad()
 {
     auto sv = (struct sysentvec*)kdlsym(self_orbis_sysvec);
     struct sysent* sysents = sv->sv_table;
-    //auto eventhandler_register = (eventhandler_tag(*)(struct eventhandler_list *list, const char *name, void *func, void *arg, int priority))kdlsym(eventhandler_register);   
+    //auto eventhandler_register = (eventhandler_tag(*)(struct eventhandler_list *list, const char *name, void *func, void *arg, int priority))kdlsym(eventhandler_register);
     auto mtx_init = (void(*)(struct mtx *m, const char *name, const char *type, int opts))kdlsym(mtx_init);
     WriteLog(LL_Info, "Loading Substitute ...");
 
@@ -122,15 +122,15 @@ Substitute* Substitute::GetPlugin()
     auto s_Framework = Mira::Framework::GetFramework();
     if (s_Framework == nullptr)
         return nullptr;
-    
+
     auto s_PluginManager = s_Framework->GetPluginManager();
     if (s_PluginManager == nullptr)
         return nullptr;
-    
+
     auto s_SubstitutePlugin = static_cast<Substitute*>(s_PluginManager->GetSubstitute());
     if (s_SubstitutePlugin == nullptr)
         return nullptr;
-    
+
     return s_SubstitutePlugin;
 }
 
@@ -326,7 +326,7 @@ int Substitute::HookIAT(struct proc* p, struct substitute_hook_uat* chain, const
         if ( (last_chain_position + 1) > SUBSTITUTE_MAX_CHAINS ) {
             WriteLog(LL_Error, "SUBSTITUTE_MAX_CHAINS reached !");
             _mtx_unlock_flags(&hook_mtx, 0, __FILE__, __LINE__);
-            
+
             return SUBSTITUTE_NOMEM;
         }
 
@@ -335,7 +335,7 @@ int Substitute::HookIAT(struct proc* p, struct substitute_hook_uat* chain, const
         if (r_error != 0) {
             WriteLog(LL_Error, "Unable to write chains structure: (%i)", r_error);
             _mtx_unlock_flags(&hook_mtx, 0, __FILE__, __LINE__);
-            
+
             return SUBSTITUTE_INVALID;
         }
 
@@ -345,7 +345,7 @@ int Substitute::HookIAT(struct proc* p, struct substitute_hook_uat* chain, const
         if (r_error != 0) {
             WriteLog(LL_Error, "Unable to read the last chain: (%d)", r_error);
             _mtx_unlock_flags(&hook_mtx, 0, __FILE__, __LINE__);
-            
+
             return SUBSTITUTE_INVALID;
         }
 
@@ -357,7 +357,7 @@ int Substitute::HookIAT(struct proc* p, struct substitute_hook_uat* chain, const
         if (r_error != 0) {
             WriteLog(LL_Error, "Unable to write chains structure: (%i)", r_error);
             _mtx_unlock_flags(&hook_mtx, 0, __FILE__, __LINE__);
-            
+
             return SUBSTITUTE_INVALID;
         }
 
@@ -372,7 +372,7 @@ int Substitute::HookIAT(struct proc* p, struct substitute_hook_uat* chain, const
         if (!original_function) {
             WriteLog(LL_Error, "Unable to get the original value from the jmpslot !");
             _mtx_unlock_flags(&hook_mtx, 0, __FILE__, __LINE__);
-            
+
             return SUBSTITUTE_INVALID;
         }
 
@@ -400,7 +400,7 @@ int Substitute::HookIAT(struct proc* p, struct substitute_hook_uat* chain, const
         if (r_error != 0) {
             WriteLog(LL_Error, "Unable to write chains structure: (%i)", r_error);
             _mtx_unlock_flags(&hook_mtx, 0, __FILE__, __LINE__);
-            
+
             // Free memory
             delete [] chains;
             return SUBSTITUTE_INVALID;
@@ -422,7 +422,7 @@ int Substitute::HookIAT(struct proc* p, struct substitute_hook_uat* chain, const
         if (r_error != 0) {
             WriteLog(LL_Error, "Unable to write to the jmpslot address: (%d)", r_error);
             _mtx_unlock_flags(&hook_mtx, 0, __FILE__, __LINE__);
-            
+
             delete[] chains;
             return SUBSTITUTE_INVALID;
         }
@@ -440,7 +440,7 @@ int Substitute::HookJmp(struct proc* p, void* original_address, void* hook_funct
     auto _mtx_unlock_flags = (void(*)(struct mtx *m, int opts, const char *file, int line))kdlsym(_mtx_unlock_flags);
 
     if (!p || !original_address || !hook_function)
-        return SUBSTITUTE_BAD_ARGS;    
+        return SUBSTITUTE_BAD_ARGS;
 
     // Get buffer from original function for calculate size
     char buffer[500];
@@ -505,21 +505,21 @@ int Substitute::DisableHook(struct proc* p, int hook_id) {
     auto _mtx_unlock_flags = (void(*)(struct mtx *m, int opts, const char *file, int line))kdlsym(_mtx_unlock_flags);
 
     // Lock the process
-    
+
     _mtx_lock_flags(&hook_mtx, 0, __FILE__, __LINE__);
 
     SubstituteHook* hook = GetHookByID(hook_id);
     if (!hook) {
         WriteLog(LL_Error, "The hook %i is not found !.", hook_id);
         _mtx_unlock_flags(&hook_mtx, 0, __FILE__, __LINE__);
-        
+
         return SUBSTITUTE_NOTFOUND;
     }
 
     if (hook->process != p) {
         WriteLog(LL_Error, "Invalid handle : Another process trying to disable hook.");
         _mtx_unlock_flags(&hook_mtx, 0, __FILE__, __LINE__);
-        
+
         return SUBSTITUTE_INVALID;
     }
 
@@ -535,7 +535,7 @@ int Substitute::DisableHook(struct proc* p, int hook_id) {
                 if (r_error != 0) {
                     WriteLog(LL_Error, "Unable to write original address: (%i)", r_error);
                     _mtx_unlock_flags(&hook_mtx, 0, __FILE__, __LINE__);
-                    
+
                     return SUBSTITUTE_BADLOGIC;
                 }
 
@@ -550,13 +550,13 @@ int Substitute::DisableHook(struct proc* p, int hook_id) {
         default: {
             WriteLog(LL_Error, "Invalid type of hook was detected.");
             _mtx_unlock_flags(&hook_mtx, 0, __FILE__, __LINE__);
-            
+
             return SUBSTITUTE_INVALID;
             break;
         }
     }
     _mtx_unlock_flags(&hook_mtx, 0, __FILE__, __LINE__);
-    
+
 
     return SUBSTITUTE_OK;
 }
@@ -565,7 +565,7 @@ int Substitute::DisableHook(struct proc* p, int hook_id) {
 int Substitute::EnableHook(struct proc* p, int hook_id) {
     auto _mtx_lock_flags = (void(*)(struct mtx *m, int opts, const char *file, int line))kdlsym(_mtx_lock_flags);
     auto _mtx_unlock_flags = (void(*)(struct mtx *m, int opts, const char *file, int line))kdlsym(_mtx_unlock_flags);
-  
+
     int r_error = -1;
 
     _mtx_lock_flags(&hook_mtx, 0, __FILE__, __LINE__);
@@ -670,7 +670,7 @@ int Substitute::Unhook(struct proc* p, int hook_id, struct substitute_hook_uat* 
             if (chain_position < 0) {
                 WriteLog(LL_Error, "Unable to get the current chain position: (%d)", chain_position);
                 _mtx_unlock_flags(&hook_mtx, 0, __FILE__, __LINE__);
-                return -4;    
+                return -4;
             }
 
             // Before need to have the address of after
@@ -866,7 +866,7 @@ uint64_t Substitute::FindJmpslotAddress(struct proc* p, const char* module_name,
 
     if (name == nullptr || p == nullptr) {
         WriteLog(LL_Error, "Invalid argument.");
-        return 0;   
+        return 0;
     }
 
     char* s_TitleId = (char*)((uint64_t)p + 0x390);
@@ -925,7 +925,7 @@ uint64_t Substitute::FindJmpslotAddress(struct proc* p, const char* module_name,
                 if (unk_obj_in_obj && unk_obj_size_in_unk_obj) {
                     uint64_t current = unk_obj_in_obj;
                     uint64_t end_addr = unk_obj_in_obj + unk_obj_size_in_unk_obj;
-                    while(current < end_addr) 
+                    while(current < end_addr)
                     {
                         uint64_t value_of_rcx = (*(uint64_t*)(current + 0x8)) >> 32;
                         uint64_t value_of_rdx = value_of_rcx * 24;
@@ -1017,7 +1017,7 @@ void Substitute::LoadAllPrx(struct thread* td, const char* folder_path)
             s_ReadCount = kgetdents_t(s_DirectoryHandle, s_Buffer, sizeof(s_Buffer), td);
             if (s_ReadCount <= 0)
                 break;
-                        
+
             for (auto l_Pos = 0; l_Pos < s_ReadCount;)
             {
                 auto l_Dent = (struct dirent*)(s_Buffer + l_Pos);
@@ -1133,7 +1133,7 @@ bool Substitute::OnProcessExecEnd(struct proc *p)
     int ret = kmkdir_t(s_substituteFullMountPath, 0511, s_MainThread);
     if (ret < 0) {
         WriteLog(LL_Error, "[%s] could not create the directory for mount (%s) (%d).", s_TitleId, s_substituteFullMountPath, ret);
-        
+
         // Restore fd and cred
         *curthread_fd = orig_curthread_fd;
         *curthread_cred = orig_curthread_cred;
@@ -1260,14 +1260,14 @@ int Substitute::Sys_dynlib_dlsym_hook(struct thread* td, struct dynlib_dlsym_arg
     if (!sys_dynlib_dlsym)
         return 1;
 
+    if (td == nullptr) {
+        WriteLog(LL_Error, "Syscall called without thread ?");
+        return 1;
+    }
+
     // Call original syscall
     int ret = sys_dynlib_dlsym(td, uap);
     int original_td_value = td->td_retval[0];
-
-    if (!td) {
-        WriteLog(LL_Error, "Syscall called without thread ?");
-        return ret;
-    }
 
     auto s_MainThread = Mira::Framework::GetFramework()->GetMainThread();
     if (!s_MainThread)
@@ -1377,7 +1377,7 @@ int Substitute::Sys_dynlib_dlsym_hook(struct thread* td, struct dynlib_dlsym_arg
         WriteLog(LL_Info, "[%s] doSubstituteLoadPRX trigerred, load prx ...", s_TitleId);
         substitute->LoadAllPrx(td, "/substitute/");
     }
-    
+
     // Restore td ret value
     td->td_retval[0] = original_td_value;
     return ret;
@@ -1391,7 +1391,7 @@ int Substitute::Sys_dynlib_dlsym_hook(struct thread* td, struct dynlib_dlsym_arg
 int Substitute::OnIoctl_HookIAT(struct thread* td, struct substitute_hook_iat* uap) {
     int hook_id = -1;
     if (!td || !uap) {
-        WriteLog(LL_Error, "Invalid argument !");        
+        WriteLog(LL_Error, "Invalid argument !");
         return EINVAL;
     }
 
@@ -1417,7 +1417,7 @@ int Substitute::OnIoctl_HookIAT(struct thread* td, struct substitute_hook_iat* u
 int Substitute::OnIoctl_HookJMP(struct thread* td, struct substitute_hook_jmp* uap) {
     int hook_id = -1;
     if (!td || !uap) {
-        WriteLog(LL_Error, "Invalid argument !");        
+        WriteLog(LL_Error, "Invalid argument !");
         return EINVAL;
     }
 
@@ -1442,7 +1442,7 @@ int Substitute::OnIoctl_HookJMP(struct thread* td, struct substitute_hook_jmp* u
 // Substitute (IOCTL) : Enable / Disable hook
 int Substitute::OnIoctl_StateHook(struct thread* td, struct substitute_state_hook* uap) {
     if (!td || !uap) {
-        WriteLog(LL_Error, "Invalid argument !");        
+        WriteLog(LL_Error, "Invalid argument !");
         return EINVAL;
     }
 
@@ -1480,14 +1480,14 @@ int Substitute::OnIoctl_StateHook(struct thread* td, struct substitute_state_hoo
                 WriteLog(LL_Info, "Hook %i disable !", uap->hook_id);
                 uap->result = ret;
             }
-            
+
             break;
         }
 
         case SUBSTITUTE_STATE_UNHOOK: {
             ret = substitute->Unhook(td->td_proc, uap->hook_id, uap->chain);
             if (ret < 0) {
-                WriteLog(LL_Error, "Unable to unhook %i (%d) !", uap->hook_id, ret);  
+                WriteLog(LL_Error, "Unable to unhook %i (%d) !", uap->hook_id, ret);
                 uap->result = ret;
             } else {
                 ret = 1;

--- a/kernel/src/Plugins/Substitute/Substitute.cpp
+++ b/kernel/src/Plugins/Substitute/Substitute.cpp
@@ -205,7 +205,8 @@ void Substitute::FreeHook(int hook_id) {
 bool Substitute::FindJmpslotSimilarity(struct proc* p, void* jmpslot_addr, int* hook_id) {
     if (!hook_id) {
         WriteLog(LL_Error, "Invalid argument !");
-        *hook_id = -1;
+        if (hook_id != nullptr)
+            *hook_id = -1;
         return false;
     }
 
@@ -1494,6 +1495,8 @@ int Substitute::OnIoctl_StateHook(struct thread* td, struct substitute_state_hoo
                 WriteLog(LL_Info, "Unhook %i was complete !", uap->hook_id);
                 uap->result = ret;
             }
+
+            break;
         }
 
         default: {

--- a/kernel/src/Plugins/Substitute/Substitute.cpp
+++ b/kernel/src/Plugins/Substitute/Substitute.cpp
@@ -907,6 +907,7 @@ uint64_t Substitute::FindJmpslotAddress(struct proc* p, const char* module_name,
                     dynlib_obj = *(uint64_t*)(dynlib_obj);
                     if (!dynlib_obj) {
                         WriteLog(LL_Error, "Unable to find the library.");
+                        A_sx_xunlock_hard(dynlib_bind_lock);
                         return 0; // Library not found
                     }
                 }

--- a/kernel/src/Plugins/Substitute/Substitute.cpp
+++ b/kernel/src/Plugins/Substitute/Substitute.cpp
@@ -205,8 +205,7 @@ void Substitute::FreeHook(int hook_id) {
 bool Substitute::FindJmpslotSimilarity(struct proc* p, void* jmpslot_addr, int* hook_id) {
     if (!hook_id) {
         WriteLog(LL_Error, "Invalid argument !");
-        if (hook_id != nullptr)
-            *hook_id = -1;
+        *hook_id = -1;
         return false;
     }
 

--- a/kernel/src/Plugins/Substitute/Substitute.cpp
+++ b/kernel/src/Plugins/Substitute/Substitute.cpp
@@ -872,7 +872,6 @@ uint64_t Substitute::FindJmpslotAddress(struct proc* p, const char* module_name,
 
     char* s_TitleId = (char*)((uint64_t)p + 0x390);
 
-
     // Get the nids of the function
     char nids[0xD] = { 0 };
     if ( (flags & SUBSTITUTE_IAT_NIDS) ) {
@@ -1247,6 +1246,11 @@ bool Substitute::OnProcessExit(struct proc *p) {
 
 // Substitute : Load PRX from Substitute folder
 int Substitute::Sys_dynlib_dlsym_hook(struct thread* td, struct dynlib_dlsym_args* uap) {
+    if (!td || !uap) {
+        WriteLog(LL_Error, "Invalid argument !");
+        return EINVAL;
+    }
+
     Substitute* substitute = GetPlugin();
     if (!substitute) {
         WriteLog(LL_Error, "Substitute dependency is needed");
@@ -1261,11 +1265,6 @@ int Substitute::Sys_dynlib_dlsym_hook(struct thread* td, struct dynlib_dlsym_arg
     auto sys_dynlib_dlsym = (int(*)(struct thread*, void*))substitute->sys_dynlib_dlsym_p;
     if (!sys_dynlib_dlsym)
         return 1;
-
-    if (td == nullptr) {
-        WriteLog(LL_Error, "Syscall called without thread ?");
-        return 1;
-    }
 
     // Call original syscall
     int ret = sys_dynlib_dlsym(td, uap);


### PR DESCRIPTION
Fixes for some warning/errors raised by PVS Studio. Some of which do appear to be actual issues rather than just nitpicking.

- `s_Proc->p_comm` to `s_Proc->p_elfpath` in `kernel/src/Driver/CtrlDriver.cpp`
- The 'td' pointer was used before it was verified in `kernel/src/Plugins/Substitute/Substitute.cpp`
- Missing A_sx_xunlock_hard call in `kernel/src/Plugins/Substitute/Substitute.cpp`

Just needs to be reviewed. Everything appears to still function correctly including substitute.