### PR TITLE
Fix Substitute plugin on 9.00 firmware

### DIFF
--- a/kernel/src/Boot/Patches/Patches900.cpp
+++ b/kernel/src/Boot/Patches/Patches900.cpp
@@ -108,7 +108,7 @@ void Mira::Boot::Patches::install_prerunPatches_900()
 	// via DeathRGH
 	kmem = (uint8_t *)&gKernelBase[0x0041F9D1];
 	kmem[0] = 0xE9;
-	kmem[1] = 0xE2;
+	kmem[1] = 0x7C;
 	kmem[2] = 0x02;
 	kmem[3] = 0x00;
 	kmem[4] = 0x00;

--- a/kernel/src/Plugins/PluginManager.cpp
+++ b/kernel/src/Plugins/PluginManager.cpp
@@ -115,7 +115,6 @@ bool PluginManager::OnLoad()
         }
 
         // Initialize Substitute
-#if MIRA_PLATFORM != MIRA_PLATFORM_ORBIS_BSD_900
         m_Substitute = new Mira::Plugins::Substitute();
         if (m_Substitute == nullptr)
         {
@@ -123,7 +122,6 @@ bool PluginManager::OnLoad()
             s_Success = false;
             break;
         }
-#endif
 
         // Initialize BrowserActivator
         m_BrowserActivator = new Mira::Plugins::BrowserActivator();
@@ -192,13 +190,11 @@ bool PluginManager::OnLoad()
             WriteLog(LL_Error, "could not load emulated registry.");
     }
 
-#if MIRA_PLATFORM != MIRA_PLATFORM_ORBIS_BSD_900
     if (m_Substitute)
     {
         if (!m_Substitute->OnLoad())
             WriteLog(LL_Error, "could not load substitute.");
     }
-#endif
 
     if (m_BrowserActivator)
     {


### PR DESCRIPTION
This cherry-picks [this older PR](https://github.com/OpenOrbis/mira-project/pull/148) and removes the ifdef guards for 9.00 firmware.