### PR TITLE
Build quick fix for LLVM 16

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -68,7 +68,7 @@ LIBS	:=
 C_DEFS	:= -D_KERNEL=1 -D_DEBUG -D_STANDALONE -D"MIRA_PLATFORM=${MIRA_PLATFORM}" -DMIRA_UNSUPPORTED_PLATFORMS -D__LP64__ -D_M_X64 -D__amd64__ -D__BSD_VISIBLE
 
 # C++ Flags, -02 Optimizations break shit badly
-CFLAGS	:= $(I_DIRS) $(C_DEFS) -fpic -m64 -O0 -fno-builtin -nodefaultlibs -nostdlib -nostdinc -fcheck-new -ffreestanding -fno-strict-aliasing -fno-exceptions -fno-asynchronous-unwind-tables -Wall -Werror -Wno-unknown-pragmas
+CFLAGS	:= $(I_DIRS) $(C_DEFS) -fpic -m64 -O0 -fno-builtin -nodefaultlibs -nostdlib -nostdinc -fcheck-new -ffreestanding -fno-strict-aliasing -fno-exceptions -fno-asynchronous-unwind-tables -fno-stack-protector -Wall -Wno-unknown-pragmas
 
 # Assembly flags
 SFLAGS	:= -m64 -nodefaultlibs -nostdlib

--- a/loader/Makefile
+++ b/loader/Makefile
@@ -17,7 +17,7 @@ PROJ_NAME := MiraLoader
 CPPC := clang
 
 # Linker
-LNK := ld # ps4-ld, we are compiling for the kernel so this is not going to use the OpenOrbis userland linker
+LNK := ld.lld
 
 # C compiler
 CC := clang

--- a/loader/Makefile
+++ b/loader/Makefile
@@ -59,7 +59,7 @@ LIBS :=
 C_DEFS := -D_KERNEL=1 -D_DEBUG -D_STANDALONE -D"MIRA_PLATFORM=${MIRA_PLATFORM}" -DMIRA_UNSUPPORTED_PLATFORMS -D__LP64__ -D_M_X64 -D__amd64__ -D__BSD_VISIBLE
 
 # C++ Flags, -02 Optimizations break shit badly
-CFLAGS := $(I_DIRS) $(C_DEFS) -fpie -fPIC -m64 -std=c++17 -O0 -fno-builtin -nodefaultlibs -nostdlib -nostdinc -fcheck-new -ffreestanding -fno-strict-aliasing -fno-exceptions -fno-asynchronous-unwind-tables -Wall -Werror -Wno-unknown-pragmas
+CFLAGS := $(I_DIRS) $(C_DEFS) -fpie -fPIC -m64 -std=c++17 -O0 -fno-builtin -nodefaultlibs -nostdlib -nostdinc -fcheck-new -ffreestanding -fno-strict-aliasing -fno-exceptions -fno-asynchronous-unwind-tables -fno-stack-protector -Wall -Werror -Wno-unknown-pragmas
 
 # Assembly flags
 SFLAGS := -fPIE -m64 -nodefaultlibs -nostdlib


### PR DESCRIPTION
This patch removes `-Werror` flag so builds don't error out on a unsafe `__builtin_frame_address()` usage warning (which doesn't seem to matter to Orbis) and some unused variables.
It also adds the `-fno-stack-protector` flag, since without it, it requires a implementation for `__stack_chk_fail` due to Mira being built for a freestanding environment (it could be implemented later if stack protection is desired).

Tested under LLVM 16.0.3, on a Base PS4 with firmware 9.00, and on top of the chendo-offset-fix branch.