### PR TITLE
Kernel: split GetProcInformation driver ioctl

### DIFF
--- a/external/freebsd-headers/include/sys/proc.h
+++ b/external/freebsd-headers/include/sys/proc.h
@@ -572,19 +572,26 @@ struct proc {
 	struct dynlib	*p_dynlib;      /* Sony Dynlib info */
 
 	// extra stuff
+	char            p_unk348[0x48];
+	char		p_titleid[10]; // 0x390
+	char            p_unk39a[0x3A];
+	char		p_contentid[64]; // 0x3d4
+
 #if MIRA_PLATFORM >= MIRA_PLATFORM_ORBIS_BSD_650
-	char            p_unk348[0x104];
+	char            p_unk414[0x38];
 #elif MIRA_PLATFORM >= MIRA_PLATFORM_ORBIS_BSD_600
-	char            p_unk348[0x100];
+	char            p_unk414[0x34];
 #elif MIRA_PLATFORM >= MIRA_PLATFORM_ORBIS_BSD_550
-	char            p_unk348[0x104];
+	char            p_unk414[0x38];
 #elif MIRA_PLATFORM >= MIRA_PLATFORM_ORBIS_BSD_500
-	char            p_unk348[0x0FC];
+	char            p_unk414[0x30];
 #elif MIRA_PLATFORM >= MIRA_PLATFORM_ORBIS_BSD_455
-	char            p_unk348[0x0F4];
+	char            p_unk414[0x28];
 #elif MIRA_PLATFORM >= MIRA_PLATFORM_ORBIS_BSD_400
+#error Reverse this struct proc portion for 4.00
 	char            p_unk348[0x0A0];
 #elif MIRA_PLATFORM >= MIRA_PLATFORM_ORBIS_BSD_355
+#error Reverse this struct proc portion for 3.55
 	char            p_unk348[0x090];
 #endif
 	
@@ -654,6 +661,21 @@ static_assert(offsetof(struct proc, p_dynlib) == 0x340, "dynlib start incorrect"
 static_assert(offsetof(struct proc, p_unk338) == 0x338, "unk338 start incorrect");
 static_assert(offsetof(struct proc, p_dynlib) == 0x340, "dynlib start incorrect");
 static_assert(offsetof(struct proc, p_magic) == 0x44C, "struct start incorrect");
+#endif
+#if MIRA_PLATFORM >= MIRA_PLATFORM_ORBIS_BSD_650
+	static_assert(sizeof(struct proc) == 0xB68, "");
+#elif MIRA_PLATFORM >= MIRA_PLATFORM_ORBIS_BSD_600
+	static_assert(sizeof(struct proc) == 0xB60, "");
+#elif MIRA_PLATFORM >= MIRA_PLATFORM_ORBIS_BSD_550
+	static_assert(sizeof(struct proc) == 0xB68, "");
+#elif MIRA_PLATFORM >= MIRA_PLATFORM_ORBIS_BSD_500
+	static_assert(sizeof(struct proc) == 0xB60, "");
+#elif MIRA_PLATFORM >= MIRA_PLATFORM_ORBIS_BSD_455
+	static_assert(sizeof(struct proc) == 0xB50, "");
+#elif MIRA_PLATFORM >= MIRA_PLATFORM_ORBIS_BSD_400
+	static_assert(sizeof(struct proc) == 0xAF8, "");
+#elif MIRA_PLATFORM >= MIRA_PLATFORM_ORBIS_BSD_355
+	static_assert(sizeof(struct proc) == 0xAE8, "");
 #endif
 
 #define	p_session	p_pgrp->pg_session

--- a/kernel/src/Driver/CtrlDriver.cpp
+++ b/kernel/src/Driver/CtrlDriver.cpp
@@ -208,8 +208,8 @@ int32_t CtrlDriver::OnMiraGetProcInformation(struct cdev* p_Device, u_long p_Com
     auto copyout = (int(*)(const void *kaddr, void *udaddr, size_t len))kdlsym(copyout);
     auto copyin = (int(*)(const void* uaddr, void* kaddr, size_t len))kdlsym(copyin);
 
-    MiraProcessInformation s_Input = { 0 };
-    auto s_Result = copyin(p_Data, &s_Input, sizeof(MiraProcessInformation));
+    MiraProcessInformation s_ProcInfo = { 0 };
+    auto s_Result = copyin(p_Data, &s_ProcInfo, sizeof(MiraProcessInformation));
     if (s_Result != 0)
     {
         WriteLog(LL_Error, "could not copyin enough data.");
@@ -217,41 +217,25 @@ int32_t CtrlDriver::OnMiraGetProcInformation(struct cdev* p_Device, u_long p_Com
     }
 
     // Get the process ID
-    auto s_ProcessId = s_Input.ProcessId;
+    // If set to 0, assume the caller wants its own process info
+    const auto s_ProcessId = s_ProcInfo.ProcessId > 0 ? s_ProcInfo.ProcessId
+	    : p_Thread->td_proc->p_pid;
 
-    // GetProcessInfo allocates
-    MiraProcessInformation* s_Output = nullptr;
-    if (!GetProcessInfo(s_ProcessId, s_Output))
+    // Fetch process info
+    if (!GetProcessInfo(s_ProcessId, &s_ProcInfo))
     {
         WriteLog(LL_Error, "could not get process information.");
         return -ENOMEM;
     }
 
-    if (s_Output == nullptr)
-    {
-        WriteLog(LL_Error, "invalid process information.");
-        return -ENOMEM;
-    }
-
-    // Check the output size
-    if (s_Input.Size < s_Output->Size)
-    {
-        WriteLog(LL_Error, "Output data not large enough (%d) < (%d).", s_Input.Size, s_Output->Size);
-        delete [] s_Output;
-        return -EMSGSIZE;
-    }
-
-    // Copy out the data if the size is large enough
-    s_Result = copyout(s_Output, p_Data, s_Output->Size);
+    // Copy out the data
+    s_Result = copyout(&s_ProcInfo, p_Data, sizeof(MiraProcessInformation));
     if (s_Result != 0)
     {
         WriteLog(LL_Error, "could not copyout (%d).", s_Result);
-        delete [] s_Output;
-        return (s_Result < 0 ? s_Result : -s_Result);
     }
 
-    delete [] s_Output;
-    return 0;
+    return (s_Result < 0 ? s_Result : -s_Result);
 }
 
 int32_t CtrlDriver::OnMiraGetProcList(struct cdev* p_Device, u_long p_Command, caddr_t p_Data, int32_t p_FFlag, struct thread* p_Thread)
@@ -626,27 +610,22 @@ int32_t CtrlDriver::OnMiraUnmountInSandbox(struct cdev* p_Device, u_long p_Comma
     return s_Result;
 }
 
-bool CtrlDriver::GetProcessInfo(int32_t p_ProcessId, MiraProcessInformation*& p_Result)
+bool CtrlDriver::GetProcessInfo(int32_t p_ProcessId, MiraProcessInformation* p_Result)
 {
-    auto spinlock_exit = (void(*)(void))kdlsym(spinlock_exit);
     auto pfind = (struct proc* (*)(pid_t processId))kdlsym(pfind);
-    //auto _mtx_lock_flags = (void(*)(struct mtx *mutex, int flags))kdlsym(_mtx_lock_flags);
-	auto _mtx_unlock_flags = (void(*)(struct mtx *mutex, int flags))kdlsym(_mtx_unlock_flags);
-    //auto _mtx_unlock_spin_flags = (void(*)(struct mtx* mutex, int flags))kdlsym(_mtx_unlock_spin_flags);
-    //auto _mtx_lock_spin_flags = (void(*)(struct mtx* mutex, int flags))kdlsym(_mtx_lock_spin_flags);
-    auto _thread_lock_flags = (void(*)(struct thread *, int, const char *, int))kdlsym(_thread_lock_flags);
+    auto _mtx_unlock_flags = (void(*)(struct mtx *mutex, int flags))kdlsym(_mtx_unlock_flags);
+
     // Check the process id (we don't allow querying kernel)
     if (p_ProcessId <= 0)
+    {
+        WriteLog(LL_Error, "ProcessId (%d) is invalid.", p_ProcessId);
         return false;
-
-    // Debugging
-    if (p_Result != nullptr)
-        WriteLog(LL_Warn, "Result is not null, is this intended?");
-
-    // Set our output pointer to null
-    p_Result = nullptr;
-
-    Vector<MiraProcessInformation::ThreadResult*> s_Threads;
+    }
+    if (p_Result == nullptr)
+    {
+        WriteLog(LL_Error, "Result is null.");
+        return false;
+    }
 
     auto s_Proc = pfind(p_ProcessId);
     if (s_Proc == nullptr)
@@ -655,124 +634,35 @@ bool CtrlDriver::GetProcessInfo(int32_t p_ProcessId, MiraProcessInformation*& p_
         return false;
     }
     // Proc is locked
-    auto s_ProcessId = s_Proc->p_pid;
-    auto s_OpPid = s_Proc->p_oppid;
-    auto s_DebugChild = s_Proc->p_dbg_child;
-    auto s_ExitThreads = s_Proc->p_exitthreads;
-    auto s_SigParent = s_Proc->p_sigparent;
-    auto s_Signal = s_Proc->p_sig;
-    auto s_Code = s_Proc->p_code;
-    auto s_Stops = s_Proc->p_stops;
-    auto s_SType = s_Proc->p_stype;
-    char s_Name[sizeof(s_Proc->p_comm)] = { 0 };
-    char s_ElfPath[sizeof(s_Proc->p_elfpath)] = { 0 };
-    char s_RandomizedPath[sizeof(s_Proc->p_randomized_path)] = { 0 };
 
-    // Copy over our names to local memory
-    memcpy(s_Name, s_Proc->p_comm, sizeof(s_Proc->p_comm));
-    memcpy(s_ElfPath, s_Proc->p_elfpath, sizeof(s_Proc->p_elfpath));
-    memcpy(s_RandomizedPath, s_Proc->p_randomized_path, sizeof(s_Proc->p_randomized_path));
+    // Copy over all of the process information
+    p_Result->ProcessId = s_Proc->p_pid;
+    p_Result->OpPid = s_Proc->p_oppid;
+    p_Result->DebugChild = s_Proc->p_dbg_child;
+    p_Result->ExitThreads = s_Proc->p_exitthreads;
+    p_Result->SigParent = s_Proc->p_sigparent;
+    p_Result->Signal = s_Proc->p_sig;
+    p_Result->Code = s_Proc->p_code;
+    p_Result->Stops = s_Proc->p_stops;
+    p_Result->SType = s_Proc->p_stype;
 
-    // Iterate through each thread in the process
-    struct thread* s_CurrentThread = nullptr;
-    FOREACH_THREAD_IN_PROC(s_Proc, s_CurrentThread)
-    {
-        // Lock the thread
-        thread_lock(s_CurrentThread);
+    // Make sure out buffer has enough size for the data
+    static_assert(sizeof(p_Result->Name) >= sizeof(s_Proc->p_comm));
+    static_assert(sizeof(p_Result->TitleId) >= sizeof(s_Proc->p_titleid));
+    static_assert(sizeof(p_Result->ContentId) >= sizeof(s_Proc->p_contentid));
+    static_assert(sizeof(p_Result->RandomizedPath) >= sizeof(s_Proc->p_randomized_path));
+    static_assert(sizeof(p_Result->ElfPath) >= sizeof(s_Proc->p_elfpath));
 
-        // Allocate a new entry
-        auto l_Info = new MiraProcessInformation::ThreadResult
-        {
-            .ThreadId = s_CurrentThread->td_tid,
-            .ErrNo = s_CurrentThread->td_errno,
-            .RetVal = s_CurrentThread->td_retval[0]
-        };
+    strlcpy(p_Result->Name, s_Proc->p_comm, sizeof(p_Result->Name));
+    strlcpy(p_Result->TitleId, s_Proc->p_titleid, sizeof(p_Result->TitleId));
+    strlcpy(p_Result->ContentId, s_Proc->p_contentid, sizeof(p_Result->ContentId));
+    strlcpy(p_Result->RandomizedPath, s_Proc->p_randomized_path, sizeof(p_Result->RandomizedPath));
+    strlcpy(p_Result->ElfPath, s_Proc->p_elfpath, sizeof(p_Result->ElfPath));
 
-        // Check if the allocation failed, it shouldn't but hey the ps4 fucks you sometimes.
-        if (l_Info == nullptr)
-        {
-            WriteLog(LL_Error, "could not get info for pid (%d) tid (%d).", s_Proc->p_pid, s_CurrentThread->td_tid);
-        }
-        else
-        {
-            memset(l_Info->Name, 0, sizeof(l_Info->Name));
-            memcpy(l_Info->Name, s_CurrentThread->td_name, sizeof(s_CurrentThread->td_name));
-
-            s_Threads.push_back(l_Info);
-        }
-
-        thread_unlock(s_CurrentThread);
-    }
     _mtx_unlock_flags(&s_Proc->p_mtx, 0);
-
     // Proc is unlocked, don't touch it anymore
 
-    // Use a dowhile here because we always want to free the resource
-    bool s_Success = false;
-    do
-    {
-        auto s_Count = s_Threads.size();
-        if (s_Count == 0 || s_Count > 2048)
-        {
-            WriteLog(LL_Error, "invalid thread count: (%d).", s_Count);
-            break;
-        }
-
-        auto s_TotalSize = ( sizeof(MiraProcessInformation) + (sizeof(MiraProcessInformation::ThreadResult) * s_Count) );
-        auto s_Output = new uint8_t[s_TotalSize];
-        if (s_Output == nullptr)
-        {
-            WriteLog(LL_Error, "could not allocate (0x%x) bytes.", s_TotalSize);
-            break;
-        }
-        memset(s_Output, 0, s_TotalSize);
-
-        // Copy over all of the process information
-        auto s_Result = reinterpret_cast<MiraProcessInformation*>(s_Output);
-        s_Result->Size = s_TotalSize;
-        s_Result->ProcessId = s_ProcessId;
-        s_Result->OpPid = s_OpPid;
-        s_Result->DebugChild = s_DebugChild;
-        s_Result->ExitThreads = s_ExitThreads;
-        s_Result->SigParent = s_SigParent;
-        s_Result->Signal = s_Signal;
-        s_Result->Code = s_Code;
-        s_Result->Stops = s_Stops;
-        s_Result->SType = s_SType;
-
-        memcpy(s_Result->Name, s_Name, sizeof(s_Name));
-        memcpy(s_Result->ElfPath, s_ElfPath, sizeof(s_Result->ElfPath));
-        memcpy(s_Result->RandomizedPath, s_RandomizedPath, sizeof(s_Result->RandomizedPath));
-
-        for (auto i = 0; i < s_Count; ++i)
-        {
-            auto l_Thread = s_Threads[i];
-            auto l_OutThread = &s_Result->Threads[i];
-
-            l_OutThread->ThreadId = l_Thread->ThreadId;
-            l_OutThread->ErrNo = l_Thread->ErrNo;
-            l_OutThread->RetVal = l_Thread->RetVal;
-            memcpy(l_OutThread->Name, l_Thread->Name, sizeof(l_OutThread->Name));
-        }
-
-        p_Result = s_Result;
-
-        s_Success = true;
-    } while (false);
-
-    // Clean up our allocations
-    for (auto i = 0; i < s_Threads.size(); ++i)
-    {
-        auto l_Info = s_Threads.at(i);
-        if (l_Info != nullptr)
-            delete l_Info;
-
-        s_Threads[i] = nullptr;
-    }
-
-    s_Threads.clear();
-
-    return s_Success;
+    return true;
 }
 
 bool CtrlDriver::GetProcessList(MiraProcessList*& p_List)

--- a/kernel/src/Driver/CtrlDriver.hpp
+++ b/kernel/src/Driver/CtrlDriver.hpp
@@ -126,8 +126,6 @@ typedef struct _MiraProcessInformation
         char Name[sizeof(((struct thread*)0)->td_name)];
     } ThreadResult;
 
-    // Structure size
-    uint32_t Size;
     int32_t ProcessId;
     int32_t OpPid;
     int32_t DebugChild;
@@ -137,11 +135,14 @@ typedef struct _MiraProcessInformation
     uint32_t Code;
     uint32_t Stops;
     uint32_t SType;
-    char Name[sizeof(((struct proc*)0)->p_comm)];
-    char ElfPath[sizeof(((struct proc*)0)->p_elfpath)];
-    char RandomizedPath[sizeof(((struct proc*)0)->p_randomized_path)];
-    ThreadResult Threads[0];
+    char Name[32];
+    char TitleId[16];
+    char ContentId[64];
+    char RandomizedPath[256];
+    char ElfPath[1024];
+    //ThreadResult Threads[0];
 } MiraProcessInformation;
+static_assert(sizeof(MiraProcessInformation) == 0x594);
 
 typedef struct _MiraProcessList
 {
@@ -241,7 +242,7 @@ namespace Mira
             static int32_t OnMiraThreadCredentials(struct cdev* p_Device, u_long p_Command, caddr_t p_Data, int32_t p_FFlag, struct thread* p_Thread);
 
             // Helper functions
-            static bool GetProcessInfo(int32_t p_ProcessId, MiraProcessInformation*& p_Result);
+            static bool GetProcessInfo(int32_t p_ProcessId, MiraProcessInformation* p_Result);
             static bool GetProcessList(MiraProcessList*& p_List);
 
             static bool GetThreadCredentials(int32_t p_ProcessId, int32_t p_ThreadId, MiraThreadCredentials*& p_Output);

--- a/kernel/src/Driver/CtrlDriver.hpp
+++ b/kernel/src/Driver/CtrlDriver.hpp
@@ -118,14 +118,6 @@ typedef enum class _MiraProcessInformationType : uint8_t
 
 typedef struct _MiraProcessInformation
 {
-    typedef struct _ThreadResult
-    {
-        int32_t ThreadId;
-        int32_t ErrNo;
-        int64_t RetVal;
-        char Name[sizeof(((struct thread*)0)->td_name)];
-    } ThreadResult;
-
     int32_t ProcessId;
     int32_t OpPid;
     int32_t DebugChild;
@@ -140,9 +132,27 @@ typedef struct _MiraProcessInformation
     char ContentId[64];
     char RandomizedPath[256];
     char ElfPath[1024];
-    //ThreadResult Threads[0];
 } MiraProcessInformation;
 static_assert(sizeof(MiraProcessInformation) == 0x594);
+
+typedef struct _MiraThreadResult
+{
+    int32_t ThreadId;
+    int32_t ErrNo;
+    int64_t RetVal;
+    char Name[36];
+} MiraThreadResult;
+static_assert(sizeof(MiraThreadResult) == 0x38);
+typedef struct _MiraThreadInformation
+{
+    // Structure size
+    uint32_t Size;
+
+    int32_t ProcessId;
+    uint32_t NumThreads;
+    MiraThreadResult Threads[];
+} MiraThreadInformation;
+static_assert(sizeof(MiraThreadInformation) == 0x10);
 
 typedef struct _MiraProcessList
 {
@@ -213,6 +223,9 @@ typedef struct _MiraGetTrainersShm
 // Get the currently loaded shm's
 #define MIRA_GET_TRAINERS_SHM _IOC(IOC_INOUT, MIRA_IOCTL_BASE, 6, sizeof(MiraGetTrainersShm));
 
+// Get thread information
+#define MIRA_GET_THRD_INFORMATION _IOC(IOC_INOUT, MIRA_IOCTL_BASE, 7, sizeof(MiraThreadInformation))
+
 namespace Mira
 {
     namespace Driver
@@ -240,6 +253,7 @@ namespace Mira
             static int32_t OnMiraMountInSandbox(struct cdev* p_Device, u_long p_Command, caddr_t p_Data, int32_t p_FFlag, struct thread* p_Thread);
             static int32_t OnMiraUnmountInSandbox(struct cdev* p_Device, u_long p_Command, caddr_t p_Data, int32_t p_FFlag, struct thread* p_Thread);
             static int32_t OnMiraThreadCredentials(struct cdev* p_Device, u_long p_Command, caddr_t p_Data, int32_t p_FFlag, struct thread* p_Thread);
+            static int32_t OnMiraGetThrdInformation(struct cdev* p_Device, u_long p_Command, caddr_t p_Data, int32_t p_FFlag, struct thread* p_Thread);
 
             // Helper functions
             static bool GetProcessInfo(int32_t p_ProcessId, MiraProcessInformation* p_Result);
@@ -247,6 +261,8 @@ namespace Mira
 
             static bool GetThreadCredentials(int32_t p_ProcessId, int32_t p_ThreadId, MiraThreadCredentials*& p_Output);
             static bool SetThreadCredentials(int32_t p_ProcessId, int32_t p_ThreadId, MiraThreadCredentials& p_Input);
+
+            static MiraThreadInformation* GetThreadInfo(int32_t p_ProcessId);
         };
     }
 }

--- a/kernel/src/OrbisOS/Utilities.cpp
+++ b/kernel/src/OrbisOS/Utilities.cpp
@@ -425,7 +425,7 @@ int Utilities::CreatePOSIXThread(struct proc* p, void* entrypoint) {
 
 	size_t s_Size = 0;
 	int s_Ret = 0;
-	char* s_TitleId = (char*)((uint64_t)p + 0x390);
+	char* s_TitleId = p->p_titleid;
 
 	WriteLog(LL_Info, "[%s] Creating POSIX Thread (Entrypoint: %p) ...", s_TitleId, entrypoint);
 
@@ -567,7 +567,7 @@ int Utilities::LoadPRXModule(struct proc* p, const char* prx_path)
 
 	size_t s_Size = 0;
 	int s_Ret = 0;
-	char* s_TitleId = (char*)((uint64_t)p + 0x390);
+	char* s_TitleId = p->p_titleid;
 
 	WriteLog(LL_Info, "[%s] Loading PRX (%s) over POSIX ...", s_TitleId, prx_path);
 

--- a/kernel/src/Plugins/FakePkg/FakePkgManager.cpp
+++ b/kernel/src/Plugins/FakePkg/FakePkgManager.cpp
@@ -434,7 +434,7 @@ void FakePkgManager::ProcessStartEvent(void *arg, struct ::proc *p)
 	if (!p)
 		return;
 
-	char* s_TitleId = (char*)((uint64_t)p + 0x390);
+	char* s_TitleId = p->p_titleid;
 	if (strncmp(s_TitleId, "NPXS20000", 9) == 0)
 		ShellCorePatch();
 

--- a/kernel/src/Plugins/MorpheusEnabler/MorpheusEnabler.cpp
+++ b/kernel/src/Plugins/MorpheusEnabler/MorpheusEnabler.cpp
@@ -36,7 +36,7 @@ void MorpheusEnabler::ProcessStartEvent(void *arg, struct ::proc *p)
     if (!p)
         return;
 
-    char* s_TitleId = (char*)((uint64_t)p + 0x390);
+    char* s_TitleId = p->p_titleid;
     if (strncmp(s_TitleId, "NPXS20000", 9) == 0)
         DoPatch();
 

--- a/kernel/src/Plugins/RemotePlayEnabler/RemotePlayEnabler.cpp
+++ b/kernel/src/Plugins/RemotePlayEnabler/RemotePlayEnabler.cpp
@@ -36,7 +36,7 @@ void RemotePlayEnabler::ProcessStartEvent(void *arg, struct ::proc *p)
 	if (!p)
 		return;
 
-	char* s_TitleId = (char*)((uint64_t)p + 0x390);
+	char* s_TitleId = p->p_titleid;
 	if (strncmp(s_TitleId, "NPXS20001", 9) == 0)
 		ShellUIPatch();
 

--- a/kernel/src/Plugins/Substitute/Substitute.cpp
+++ b/kernel/src/Plugins/Substitute/Substitute.cpp
@@ -769,7 +769,7 @@ void Substitute::CleanupProcessHook(struct proc* p) {
     if (!p)
         return;
 
-    char* s_TitleId = (char*)((uint64_t)p + 0x390);
+    char* s_TitleId = p->p_titleid;
     WriteLog(LL_Info, "Cleaning up hook for %s", s_TitleId);
 
 
@@ -799,8 +799,7 @@ void* Substitute::FindOriginalAddress(struct proc* p, const char* name, int32_t 
     if (p == nullptr)
         return nullptr;
 
-    // TODO: Fix this structure within proc
-    char* s_TitleId = (char*)((uint64_t)p + 0x390);
+    char* s_TitleId = p->p_titleid;
     void* s_Address = nullptr;
 
     WriteLog(LL_Info, "TitleId: (%s).", s_TitleId);
@@ -869,7 +868,7 @@ uint64_t Substitute::FindJmpslotAddress(struct proc* p, const char* module_name,
         return 0;
     }
 
-    char* s_TitleId = (char*)((uint64_t)p + 0x390);
+    char* s_TitleId = p->p_titleid;
 
     // Get the nids of the function
     char nids[0xD] = { 0 };
@@ -1000,7 +999,7 @@ void Substitute::LoadAllPrx(struct thread* td, const char* folder_path)
         return;
     }
 
-    char* s_TitleId = (char*)((uint64_t)td->td_proc + 0x390);
+    char* s_TitleId = td->td_proc->p_titleid;
 
     // Opening substitute folder
     auto s_DirectoryHandle = kopen_t(folder_path, O_RDONLY | O_DIRECTORY, 0777, td);
@@ -1059,7 +1058,7 @@ bool Substitute::OnProcessExecEnd(struct proc *p)
     auto vn_fullpath = (int(*)(struct thread *td, struct vnode *vp, char **retbuf, char **freebuf))kdlsym(vn_fullpath);
 
     struct thread* s_ProcessThread = FIRST_THREAD_IN_PROC(p);
-    char* s_TitleId = (char*)((uint64_t)p + 0x390);
+    char* s_TitleId = p->p_titleid;
 
     // Check if it's a valid process
     if ( !s_TitleId || s_TitleId[0] == 0 )
@@ -1173,7 +1172,7 @@ bool Substitute::OnProcessExit(struct proc *p) {
 
     // Get process information
     struct thread* s_ProcessThread = FIRST_THREAD_IN_PROC(p);
-    char* s_TitleId = (char*)((uint64_t)p + 0x390);
+    char* s_TitleId = p->p_titleid;
 
     Substitute* substitute = GetPlugin();
 
@@ -1277,7 +1276,7 @@ int Substitute::Sys_dynlib_dlsym_hook(struct thread* td, struct dynlib_dlsym_arg
         return ret;
     }
 
-    char* s_TitleId = (char*)((uint64_t)td->td_proc + 0x390);
+    char* s_TitleId = td->td_proc->p_titleid;
 
     // Check if it's a valid process
     if ( !s_TitleId || s_TitleId[0] == 0) {

--- a/kernel/src/Plugins/Substitute2/Substitute2.cpp
+++ b/kernel/src/Plugins/Substitute2/Substitute2.cpp
@@ -23,7 +23,7 @@ bool Substitute2::OnProcessExecEnd(struct proc* p_Process)
         return true;
     
     // Check the title id's against the supported
-    const char* s_TitleId = &p_Process->p_unk348[0x58];
+    const char* s_TitleId = p_Process->p_titleid;
     if (s_TitleId == nullptr)
         return false;
 

--- a/kernel/src/Utils/Kernel.cpp
+++ b/kernel/src/Utils/Kernel.cpp
@@ -17,12 +17,12 @@ extern "C"
 
 int proc_rw_mem(struct proc* p, void* ptr, size_t size, void* data, size_t* n, int write) 
 {
-	auto s_DebuggerThread = Mira::Framework::GetFramework()->GetSyscoreThread();
-	if (s_DebuggerThread == nullptr)
-	{
-		WriteLog(LL_Error, "could not get debugger thread.");
-		return -EIO;
-	}
+    auto s_DebuggerThread = Mira::Framework::GetFramework()->GetSyscoreThread();
+    if (s_DebuggerThread == nullptr)
+    {
+        WriteLog(LL_Error, "could not get debugger thread.");
+        return -EIO;
+    }
 
     auto proc_rwmem = (int(*)(struct proc* p, struct uio* uio))kdlsym(proc_rwmem);
     struct thread* td = s_DebuggerThread;
@@ -141,3 +141,19 @@ void build_iovec(struct iovec **iov, int *iovlen, const char *name, const char *
 
     *iovlen = ++i;
 }
+
+//
+// strlcpy implementation taken from http://www.musl-libc.org/
+// which is licensed under the standard MIT license
+//
+size_t strlcpy(char *d, const char *s, size_t n)
+{
+    char *d0 = d;
+
+    if (!n--) goto finish;
+    for (; n && (*d=*s); n--, s++, d++);
+    *d = 0;
+finish:
+    return d-d0 + strlen(s);
+}
+

--- a/kernel/src/Utils/Kernel.hpp
+++ b/kernel/src/Utils/Kernel.hpp
@@ -75,6 +75,7 @@ extern int	 memcmp(const void *, const void *, size_t);
 
 extern size_t strlen(const char *str);
 extern int strcmp(const char *str1, const char *str2);
+extern size_t strlcpy(char *d, const char *s, size_t n);
 
 extern void cpu_enable_wp();
 extern void cpu_disable_wp();


### PR DESCRIPTION
This set of patches purposes changing MIRA_GET_PROC_INFORMATION ioctl by separating thread information to a new ioctl, MIRA_GET_THRD_INFORMATION, along with some new information fields for GET_PROC_INFORMATION.

The motivations for this are retrieval of additional information and improved ease of use for callers.
Other included changes are:
- Remove Threads field from MiraProcessInformation, and use fixed numbers for its strings.
- If the requested PID is 0, assume the caller wants its own process' information.
- Pass the number of threads retrieved to the caller
- Use (musl's implementation of) strlcpy to safely copy process and thread strings
- Replaced offset references of title ID with p_titleid field.

If the ioctl split is unwanted (or anything else), I can rework the patches as desired.

This was tested on a Base PS4 9.00, LLVM 16.0.3, on top of the chendo-offset-fix branch and the patches of #162

EDIT:
Other firmware offsets for title ID and content ID are unconfirmed