### PR TITLE
Kernel: use correct deci_tty_write hook offset in 9.00

### DIFF
--- a/kernel/src/Utils/Kdlsym/Orbis900.hpp
+++ b/kernel/src/Utils/Kdlsym/Orbis900.hpp
@@ -187,7 +187,7 @@
 #define kdlsym_addr_sys_sysctl                             0x2A2E90
 
 // Kernel Hooks
-#define kdlsym_addr_printf_hook                            0x01A7ED68
+#define kdlsym_addr_printf_hook                            0x01A7ED98
 
 // FakeSelf Hooks
 #define kdlsym_addr_sceSblAuthMgrIsLoadable__sceSblACMgrGetPathId_hook        0x0064473C


### PR DESCRIPTION
The TTYRedirector plugin uses printf_hook's offset to replace in the  deci_tty_cdev's `struct cdevsw` instance, the d_write field.
This patch sets the offset to the d_write field itself, where it previously was pointing to the start of the cdevsw instance.

This affects firmware version 9.00.
Tested with LLVM 16.0.3 and on top of the chendo-offset-fix branch and #162