### PR TITLE
Substitute: load .prx libraries

### DIFF
--- a/kernel/src/Plugins/Substitute/Substitute.cpp
+++ b/kernel/src/Plugins/Substitute/Substitute.cpp
@@ -1023,8 +1023,9 @@ void Substitute::LoadAllPrx(struct thread* td, const char* folder_path)
                 auto l_Dent = (struct dirent*)(s_Buffer + l_Pos);
                 s_DentCount++;
 
-                // Check if the sprx is legit
-                if (strstr(l_Dent->d_name, ".sprx")) {
+                // Check if the (s)prx is legit
+                if (strstr(l_Dent->d_name, ".prx")
+                  || strstr(l_Dent->d_name, ".sprx")) {
                     // Generating relative path
                     char s_RelativeSprxPath[PATH_MAX];
                     snprintf(s_RelativeSprxPath, PATH_MAX, "%s%s", folder_path, l_Dent->d_name);


### PR DESCRIPTION
This patch has Substitute loading .prx files, since there is functionality already in Mira to load fake PRXs.

Tested on a 9.00 base PS4, LLVM 16.0.3 and on top of the chendo-offset-fix branch and #162